### PR TITLE
ci: JavaScript 액션을 Node.js 24 런타임으로 강제

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,13 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # GitHub Actions runner는 2026-06-02부터 Node.js 24를 강제하고
+  # 2026-09-16부터 Node 20을 제거한다. JavaScript 액션들이 매 실행마다
+  # deprecation 경고를 띄우는 것을 막고 강제 전환 시점에 깨지지 않도록
+  # 명시적으로 Node 24 런타임을 opt-in.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   # 변경 영역 감지 — 후속 잡들은 outputs에 의존해서 조건부 실행.
   changes:


### PR DESCRIPTION
## 요약

Closes #10

GitHub Actions runner의 Node 20 deprecation에 미리 대응. \`.github/workflows/ci.yml\`에 워크플로우 레벨 \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true\` env 추가.

## 변경 사항

- \`.github/workflows/ci.yml\` (+7 lines): \`concurrency:\` 블록 바로 아래에 \`env:\` 블록 신규

## 기술적 판단

- **워크플로우 레벨 env** (잡/스텝 레벨 X) — 5 잡 모두 외부 JavaScript 액션을 사용하므로 균일 적용이 자연스럽고 누락 위험 0.
- 우리 워크플로우의 외부 액션(\`actions/checkout@v4\`, \`dorny/paths-filter@v3\`, \`actions/setup-python@v5\`, \`astral-sh/setup-uv@v6\`, \`actions/setup-node@v4\`)은 모두 최신 메이저 — Node 24 강제 시 깨질 가능성 낮음. PR 자체에서 검증.

## 검증

| 항목 | 결과 |
|---|---|
| YAML 문법 | python yaml.safe_load 통과 |
| 워크플로우 자체 발동 | 이 PR 생성 후 \`gh run watch\`로 확인 |
| 5 잡 그린 | PR Checks |
| deprecation 경고 사라짐 | run view annotations |

## 배경

GitHub deprecation 메시지:
> Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

명시적 opt-in으로 미리 대응. 액션 메인테이너들이 Node 24 호환 버전을 release하는 시점과 무관하게 우리 CI는 명확한 상태가 된다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration for improved compatibility with GitHub Actions runtime environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->