### PR TITLE
feat: MM 봇 (spec v2) — 엔진 통합 + 양방향 호가 + 온체인 예치·취소

### DIFF
--- a/apps/engine/.env.example
+++ b/apps/engine/.env.example
@@ -39,7 +39,8 @@ NVIDIA_ATTESTATION_URL=https://nras.attestation.nvidia.com/v3/attest/gpu
 # MM Bot (mm_config.yaml enabled=true 일 때)
 # BSC 테스트넷 faucet WBNB/USDT 보유 지갑. TEE_PRIVATE_KEY 와 분리 권장.
 MM_BOT_PRIVATE_KEY=
-# 온체인 없이 오더북만 테스트할 때 1
-MM_BOT_DRY_RUN=0
+# 기본은 dry-run. 실제 BSC 테스트넷 트랜잭션을 쏘려면 0 으로 바꾸고
+# MM_BOT_PRIVATE_KEY 가 faucet 잔고를 가진 상태인지 확인할 것.
+MM_BOT_DRY_RUN=1
 # BEP-20 decimals (기본 18)
 MM_TOKEN_DECIMALS=18

--- a/apps/engine/.env.example
+++ b/apps/engine/.env.example
@@ -35,3 +35,11 @@ NEAR_AI_JSON_RESPONSE_FORMAT=1
 NEARAI_CLOUD_API_KEY=
 NEARAI_CLOUD_BASE_URL=https://cloud-api.near.ai
 NVIDIA_ATTESTATION_URL=https://nras.attestation.nvidia.com/v3/attest/gpu
+
+# MM Bot (mm_config.yaml enabled=true 일 때)
+# BSC 테스트넷 faucet WBNB/USDT 보유 지갑. TEE_PRIVATE_KEY 와 분리 권장.
+MM_BOT_PRIVATE_KEY=
+# 온체인 없이 오더북만 테스트할 때 1
+MM_BOT_DRY_RUN=0
+# BEP-20 decimals (기본 18)
+MM_TOKEN_DECIMALS=18

--- a/apps/engine/mm_config.yaml
+++ b/apps/engine/mm_config.yaml
@@ -39,7 +39,10 @@ mm_bot:
     price_refresh_threshold_pct: 0.05
 
   onchain:
-    # BSC Testnet 기본 — Track B / mainnet은 환경변수로 전환
-    base_token: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c"
-    quote_token: "0x55d398326f99059fF775485246999027B3197955"
+    # BSC Testnet 주소. price_feed 는 mainnet Pancake/Binance 레퍼런스 가격을
+    # 가져오지만 deposit/cancel 은 BSC_TESTNET_RPC 로 발생하므로 여기 토큰도
+    # 테스트넷 주소여야 한다. quote_token 은 사용자가 보유한 테스트넷
+    # 스테이블 주소로 교체해야 한다 (공식 테스트넷 USDT 는 없음).
+    base_token: "0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd"  # BSC Testnet WBNB
+    quote_token: ""  # TODO: 사용자가 보유한 BSC Testnet 스테이블 주소로 설정
     gas_price_gwei: 10

--- a/apps/engine/mm_config.yaml
+++ b/apps/engine/mm_config.yaml
@@ -1,0 +1,45 @@
+# DarkPool Lite — AI Market Maker (Track A: testnet demo)
+# 비활성화하려면 enabled: false
+
+mm_bot:
+  enabled: false
+  pairs:
+    - base: BNB
+      quote: USDT
+      token_pair: "BNB/USDT"
+      initial_inventory_base: 1000
+      initial_inventory_quote: 300000
+
+  pricing:
+    sources:
+      - name: pancakeswap_v3
+        weight: 0.6
+      - name: binance_spot
+        weight: 0.4
+    polling_interval_sec: 5
+    outlier_threshold_pct: 2.0
+
+  spread:
+    base_bps: 30
+    min_bps: 10
+    max_bps: 200
+    vol_window_sec: 60
+    vol_multiplier_max: 3.0
+
+  risk:
+    max_exposure_pct: 70
+    rebalance_threshold_pct: 60
+    price_shock_pct: 5.0
+    price_shock_window_sec: 60
+    min_inventory_pct: 5.0
+
+  order:
+    default_size_base: 100
+    refresh_interval_sec: 5
+    price_refresh_threshold_pct: 0.05
+
+  onchain:
+    # BSC Testnet 기본 — Track B / mainnet은 환경변수로 전환
+    base_token: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c"
+    quote_token: "0x55d398326f99059fF775485246999027B3197955"
+    gas_price_gwei: 10

--- a/apps/engine/pyproject.toml
+++ b/apps/engine/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "web3>=7.0,<8.0",
     "httpx>=0.27,<1.0",
     "openai>=1.30,<2.0",
+    "pyyaml>=6.0,<7.0",
 ]
 
 [dependency-groups]

--- a/apps/engine/src/main.py
+++ b/apps/engine/src/main.py
@@ -7,6 +7,8 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from src.mm_bot.bot import MMBot
+from src.mm_bot.config import load_mm_settings
 from src.models import OrderBook
 from src.routes import router
 from src.ws import ConnectionManager
@@ -19,7 +21,27 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.orderbook = OrderBook()
     app.state.ws_manager = ConnectionManager()
     app.state.background_tasks: set[asyncio.Task] = set()
+    app.state.mm_bot = None
+
+    mm_settings = load_mm_settings()
+    if mm_settings.enabled:
+        mm_bot = MMBot(
+            settings=mm_settings,
+            orderbook=app.state.orderbook,
+            ws_manager=app.state.ws_manager,
+        )
+        app.state.mm_bot = mm_bot
+        mm_task = asyncio.create_task(mm_bot.run_forever())
+        app.state.background_tasks.add(mm_task)
+        mm_task.add_done_callback(app.state.background_tasks.discard)
+        logger.info("MM 봇 태스크 등록됨 (mm_config.yaml enabled=true)")
+
     yield
+
+    mm = getattr(app.state, "mm_bot", None)
+    if mm is not None:
+        mm.stop()
+
     # 백그라운드 태스크 정리
     tasks: set[asyncio.Task] = getattr(app.state, "background_tasks", set())
     for task in tasks:

--- a/apps/engine/src/matching/runner.py
+++ b/apps/engine/src/matching/runner.py
@@ -1,0 +1,51 @@
+"""백그라운드 매칭 사이클 — API 라우트와 MM 봇이 공유."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from src.matching.engine import MatchingEngine
+from src.models import OrderBook
+from src.signer.pipeline import process_match_results
+from src.ws import ConnectionManager
+
+logger = logging.getLogger(__name__)
+
+
+async def run_matching_cycle(
+    orderbook: OrderBook,
+    token_pair: str,
+    ws_manager: ConnectionManager,
+    *,
+    mm_bot: Any | None = None,
+) -> None:
+    """매칭 → 서명 → 제출 → WS 알림. MM 봇은 체결 후 재고 갱신 훅을 받는다."""
+    try:
+        engine = MatchingEngine(orderbook)
+        results = await engine.run_matching_cycle(token_pair)
+        if not results:
+            return
+
+        outcomes = await asyncio.to_thread(process_match_results, results)
+
+        if mm_bot is not None and hasattr(mm_bot, "on_match_outcomes"):
+            try:
+                mm_bot.on_match_outcomes(outcomes, orderbook)
+            except Exception:
+                logger.exception("MM 봇 on_match_outcomes 실패")
+
+        await ws_manager.broadcast({"action": "matched", "results": outcomes})
+
+        submitted = [o for o in outcomes if o.get("tx_hash")]
+        if submitted:
+            logger.info(
+                "매칭 사이클 완료: %d건 체결, %d건 BSC 제출",
+                len(results),
+                len(submitted),
+            )
+        else:
+            logger.info("매칭 사이클 완료: %d건 체결 (BSC 미설정)", len(results))
+    except Exception:
+        logger.exception("매칭 사이클 실패: token_pair=%s", token_pair)

--- a/apps/engine/src/mm_bot/__init__.py
+++ b/apps/engine/src/mm_bot/__init__.py
@@ -1,0 +1,6 @@
+"""AI Market Maker 봇 (Track A 테스트넷 데모)."""
+
+from src.mm_bot.bot import MMBot
+from src.mm_bot.config import load_mm_settings
+
+__all__ = ["MMBot", "load_mm_settings"]

--- a/apps/engine/src/mm_bot/bot.py
+++ b/apps/engine/src/mm_bot/bot.py
@@ -209,28 +209,47 @@ class MMBot:
         st = self._pair_states[token_pair]
         for key in ("active_buy", "active_sell"):
             oid = st.get(key)
-            if oid:
-                await self._safe_cancel_order(oid)
+            if not oid:
+                continue
+            ok = await self._safe_cancel_order(oid)
+            if ok:
                 st[key] = None
+            else:
+                # 취소 확정 실패 → 에스크로에 예치가 남아있는 상태.
+                # state 를 비우면 봇이 다음 tick 에 새 예치·주문을 만들어
+                # 재고·에스크로 불일치를 일으킨다. 그대로 두면 다음 tick 의
+                # _refresh_quotes 가 다시 취소를 재시도한다.
+                logger.warning(
+                    "MM 주문 취소 확정 실패 — state 유지 (다음 tick 재시도): order=%s",
+                    oid[:8],
+                )
 
-    async def _safe_cancel_order(self, order_id: str) -> None:
+    async def _safe_cancel_order(self, order_id: str) -> bool:
+        """취소 확정 시 True, 확정 실패 시 False.
+
+        Escrow 가 enabled 면 on-chain cancel 이 tx hash 를 돌려줘야 확정으로 간주.
+        enabled 가 아니면 로컬 오더북에서만 제거하고 True.
+        """
         for attempt in range(3):
             try:
                 if self._escrow.enabled:
                     txh = await asyncio.to_thread(self._escrow.cancel_order, order_id)
-                    if txh is None and attempt < 2:
-                        await asyncio.sleep(1.0)
-                        continue
+                    if txh is None:
+                        if attempt < 2:
+                            await asyncio.sleep(1.0)
+                            continue
+                        return False
                 o = self._orderbook.get(order_id)
                 if o and o.is_active:
                     try:
                         self._orderbook.cancel(order_id)
                     except (KeyError, ValueError):
                         pass
-                return
+                return True
             except Exception:
                 logger.exception("MM 주문 취소 실패 order=%s attempt=%s", order_id[:8], attempt + 1)
                 await asyncio.sleep(0.5)
+        return False
 
     async def _refresh_quotes(
         self,

--- a/apps/engine/src/mm_bot/bot.py
+++ b/apps/engine/src/mm_bot/bot.py
@@ -10,16 +10,15 @@ from decimal import Decimal
 from typing import TYPE_CHECKING
 
 from src.matching.runner import run_matching_cycle
-from src.models.order import Order
-from src.models.orderbook import OrderBook
-from src.ws import ConnectionManager
-
 from src.mm_bot.escrow_client import MMEscrowClient, decimal_to_wei
 from src.mm_bot.inventory import InventoryState
 from src.mm_bot.order_gen import bid_ask_prices
 from src.mm_bot.price_feed import PriceFeedListener, wall_time
 from src.mm_bot.risk import RiskConfig, RiskController
 from src.mm_bot.spread import SpreadCalculator, SpreadConfig
+from src.models.order import Order
+from src.models.orderbook import OrderBook
+from src.ws import ConnectionManager
 
 if TYPE_CHECKING:
     from src.mm_bot.config import MMSettings
@@ -146,7 +145,11 @@ class MMBot:
 
     async def run_forever(self) -> None:
         self._running = True
-        logger.info("MM 봇 시작 wallet=%s onchain=%s", self._wallet or "(none)", self._escrow.enabled)
+        logger.info(
+            "MM 봇 시작 wallet=%s onchain=%s",
+            self._wallet or "(none)",
+            self._escrow.enabled,
+        )
         while self._running:
             try:
                 for pair in self._cfg.pairs:

--- a/apps/engine/src/mm_bot/bot.py
+++ b/apps/engine/src/mm_bot/bot.py
@@ -64,25 +64,21 @@ class MMBot:
         )
 
         sp = settings.spread
-        self._spread_calc = SpreadCalculator(
-            SpreadConfig(
-                base_bps=float(sp.get("base_bps", 30)),
-                min_bps=float(sp.get("min_bps", 10)),
-                max_bps=float(sp.get("max_bps", 200)),
-                vol_window_sec=float(sp.get("vol_window_sec", 60)),
-                vol_multiplier_max=float(sp.get("vol_multiplier_max", 3.0)),
-            )
+        self._spread_cfg = SpreadConfig(
+            base_bps=float(sp.get("base_bps", 30)),
+            min_bps=float(sp.get("min_bps", 10)),
+            max_bps=float(sp.get("max_bps", 200)),
+            vol_window_sec=float(sp.get("vol_window_sec", 60)),
+            vol_multiplier_max=float(sp.get("vol_multiplier_max", 3.0)),
         )
 
         rk = settings.risk
-        self._risk = RiskController(
-            RiskConfig(
-                max_exposure_pct=float(rk.get("max_exposure_pct", 70)),
-                rebalance_threshold_pct=float(rk.get("rebalance_threshold_pct", 60)),
-                price_shock_pct=float(rk.get("price_shock_pct", 5.0)),
-                price_shock_window_sec=float(rk.get("price_shock_window_sec", 60)),
-                min_inventory_pct=float(rk.get("min_inventory_pct", 5.0)),
-            )
+        self._risk_cfg = RiskConfig(
+            max_exposure_pct=float(rk.get("max_exposure_pct", 70)),
+            rebalance_threshold_pct=float(rk.get("rebalance_threshold_pct", 60)),
+            price_shock_pct=float(rk.get("price_shock_pct", 5.0)),
+            price_shock_window_sec=float(rk.get("price_shock_window_sec", 60)),
+            min_inventory_pct=float(rk.get("min_inventory_pct", 5.0)),
         )
 
         od = settings.order
@@ -100,8 +96,14 @@ class MMBot:
         self._wallet = self._escrow.address or ""
         self._wallet_lower = self._wallet.lower()
 
+        # SpreadCalculator/RiskController 는 mutable history 를 pair 별로
+        # 들고 있어야 한다 (BNB/USDT 의 변동성이 ETH/USDT 와 섞이면 안 됨).
+        self._spread_calc_by_pair: dict[str, SpreadCalculator] = {}
+        self._risk_by_pair: dict[str, RiskController] = {}
         self._pair_states: dict[str, dict] = {}
         for p in settings.pairs:
+            self._spread_calc_by_pair[p.token_pair] = SpreadCalculator(self._spread_cfg)
+            self._risk_by_pair[p.token_pair] = RiskController(self._risk_cfg)
             self._pair_states[p.token_pair] = {
                 "inventory": InventoryState(
                     initial_base=Decimal(str(p.initial_inventory_base)),
@@ -169,33 +171,36 @@ class MMBot:
         if st is None:
             return
 
+        spread_calc = self._spread_calc_by_pair[token_pair]
+        risk = self._risk_by_pair[token_pair]
+
         res = await self._price_feed.get_mid_price(token_pair)
         now = wall_time()
 
         if res.mid is None:
-            self._risk.mark_feed_failed(True)
+            risk.mark_feed_failed(True)
             async with self._lock:
                 await self._cancel_all_mm_orders(token_pair)
             return
 
-        self._risk.mark_feed_failed(False)
+        risk.mark_feed_failed(False)
         mid = res.mid
-        self._risk.record_price(now, mid)
-        self._spread_calc.record_mid(now, mid)
+        risk.record_price(now, mid)
+        spread_calc.record_mid(now, mid)
 
-        if not self._risk.can_quote(now):
+        if not risk.can_quote(now):
             async with self._lock:
                 await self._cancel_all_mm_orders(token_pair)
             return
 
         inv: InventoryState = st["inventory"]
-        spread_bps = self._spread_calc.effective_spread_bps()
+        spread_bps = spread_calc.effective_spread_bps()
         bid_px, ask_px = bid_ask_prices(mid, spread_bps)
 
         st["last_mid"] = mid
 
-        can_bid = self._risk.can_quote_bid(inv, Decimal(str(mid)))
-        can_ask = self._risk.can_quote_ask(inv, Decimal(str(mid)))
+        can_bid = risk.can_quote_bid(inv, Decimal(str(mid)))
+        can_ask = risk.can_quote_ask(inv, Decimal(str(mid)))
 
         async with self._lock:
             await self._refresh_quotes(token_pair, bid_px, ask_px, can_bid, can_ask)

--- a/apps/engine/src/mm_bot/bot.py
+++ b/apps/engine/src/mm_bot/bot.py
@@ -84,6 +84,7 @@ class MMBot:
         od = settings.order
         self._refresh_sec = float(od.get("refresh_interval_sec", 5))
         self._default_size = Decimal(str(od.get("default_size_base", 100)))
+        self._refresh_threshold_pct = float(od.get("price_refresh_threshold_pct", 0.05))
 
         oc = settings.onchain
         self._base_token = oc.base_token if oc else ""
@@ -110,6 +111,9 @@ class MMBot:
                     initial_quote=Decimal(str(p.initial_inventory_quote)),
                 ),
                 "last_mid": None,
+                "last_quoted_mid": None,
+                "prev_can_bid": None,
+                "prev_can_ask": None,
                 "active_buy": None,
                 "active_sell": None,
             }
@@ -181,6 +185,8 @@ class MMBot:
             risk.mark_feed_failed(True)
             async with self._lock:
                 await self._cancel_all_mm_orders(token_pair)
+            # 피드 복구 후에는 무조건 재주문이 필요하므로 threshold 기준점을 리셋
+            st["last_quoted_mid"] = None
             return
 
         risk.mark_feed_failed(False)
@@ -191,6 +197,7 @@ class MMBot:
         if not risk.can_quote(now):
             async with self._lock:
                 await self._cancel_all_mm_orders(token_pair)
+            st["last_quoted_mid"] = None
             return
 
         inv: InventoryState = st["inventory"]
@@ -202,8 +209,37 @@ class MMBot:
         can_bid = risk.can_quote_bid(inv, Decimal(str(mid)))
         can_ask = risk.can_quote_ask(inv, Decimal(str(mid)))
 
+        # 가격 변화가 threshold 이내이고 side 판정이 그대로면 재주문 생략 →
+        # 매 tick 마다 불필요한 cancel+deposit 체인으로 가스 낭비하지 않도록.
+        if self._should_skip_refresh(st, mid, can_bid, can_ask):
+            return
+
         async with self._lock:
             await self._refresh_quotes(token_pair, bid_px, ask_px, can_bid, can_ask)
+        st["last_quoted_mid"] = mid
+        st["prev_can_bid"] = can_bid
+        st["prev_can_ask"] = can_ask
+
+    def _should_skip_refresh(
+        self,
+        st: dict,
+        mid: float,
+        can_bid: bool,
+        can_ask: bool,
+    ) -> bool:
+        last = st.get("last_quoted_mid")
+        if last is None:
+            return False
+        if st.get("prev_can_bid") != can_bid or st.get("prev_can_ask") != can_ask:
+            return False
+        try:
+            prev = float(last)
+        except (TypeError, ValueError):
+            return False
+        if prev <= 0:
+            return False
+        change_pct = abs(mid - prev) / prev * 100.0
+        return change_pct < self._refresh_threshold_pct
 
     async def _cancel_all_mm_orders(self, token_pair: str) -> None:
         st = self._pair_states[token_pair]

--- a/apps/engine/src/mm_bot/bot.py
+++ b/apps/engine/src/mm_bot/bot.py
@@ -1,0 +1,296 @@
+"""MM 봇 메인 루프 — 호가 갱신, 오더북 반영, 온체인 예치·취소."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import uuid
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from src.matching.runner import run_matching_cycle
+from src.models.order import Order
+from src.models.orderbook import OrderBook
+from src.ws import ConnectionManager
+
+from src.mm_bot.escrow_client import MMEscrowClient, decimal_to_wei
+from src.mm_bot.inventory import InventoryState
+from src.mm_bot.order_gen import bid_ask_prices
+from src.mm_bot.price_feed import PriceFeedListener, wall_time
+from src.mm_bot.risk import RiskConfig, RiskController
+from src.mm_bot.spread import SpreadCalculator, SpreadConfig
+
+if TYPE_CHECKING:
+    from src.mm_bot.config import MMSettings
+
+logger = logging.getLogger(__name__)
+
+
+def _env_token_decimals() -> int:
+    try:
+        return int(os.environ.get("MM_TOKEN_DECIMALS", "18"))
+    except ValueError:
+        return 18
+
+
+class MMBot:
+    """스펙 v2 Lean: 테스트넷에서 양방향 호가를 유지하고 체결 시 재고를 갱신한다."""
+
+    def __init__(
+        self,
+        *,
+        settings: MMSettings,
+        orderbook: OrderBook,
+        ws_manager: ConnectionManager,
+    ) -> None:
+        self._cfg = settings
+        self._orderbook = orderbook
+        self._ws = ws_manager
+        self._running = False
+
+        pr = settings.pricing
+        sources = pr.get("sources") or []
+        if len(sources) >= 2 and isinstance(sources[0], dict) and isinstance(sources[1], dict):
+            w0 = float(sources[0].get("weight", 0.6))
+            w1 = float(sources[1].get("weight", 0.4))
+            tot = w0 + w1
+            pw, bw = (w0 / tot, w1 / tot) if tot > 0 else (0.6, 0.4)
+        else:
+            pw, bw = 0.6, 0.4
+        self._price_feed = PriceFeedListener(
+            pancake_weight=pw,
+            binance_weight=bw,
+            outlier_threshold_pct=float(pr.get("outlier_threshold_pct", 2.0)),
+        )
+
+        sp = settings.spread
+        self._spread_calc = SpreadCalculator(
+            SpreadConfig(
+                base_bps=float(sp.get("base_bps", 30)),
+                min_bps=float(sp.get("min_bps", 10)),
+                max_bps=float(sp.get("max_bps", 200)),
+                vol_window_sec=float(sp.get("vol_window_sec", 60)),
+                vol_multiplier_max=float(sp.get("vol_multiplier_max", 3.0)),
+            )
+        )
+
+        rk = settings.risk
+        self._risk = RiskController(
+            RiskConfig(
+                max_exposure_pct=float(rk.get("max_exposure_pct", 70)),
+                rebalance_threshold_pct=float(rk.get("rebalance_threshold_pct", 60)),
+                price_shock_pct=float(rk.get("price_shock_pct", 5.0)),
+                price_shock_window_sec=float(rk.get("price_shock_window_sec", 60)),
+                min_inventory_pct=float(rk.get("min_inventory_pct", 5.0)),
+            )
+        )
+
+        od = settings.order
+        self._refresh_sec = float(od.get("refresh_interval_sec", 5))
+        self._default_size = Decimal(str(od.get("default_size_base", 100)))
+
+        oc = settings.onchain
+        self._base_token = oc.base_token if oc else ""
+        self._quote_token = oc.quote_token if oc else ""
+        self._gas_gwei = oc.gas_price_gwei if oc else 10
+
+        pk = os.environ.get("MM_BOT_PRIVATE_KEY", "").strip()
+        self._escrow = MMEscrowClient(private_key=pk or None, gas_price_gwei=self._gas_gwei)
+
+        self._wallet = self._escrow.address or ""
+        self._wallet_lower = self._wallet.lower()
+
+        self._pair_states: dict[str, dict] = {}
+        for p in settings.pairs:
+            self._pair_states[p.token_pair] = {
+                "inventory": InventoryState(
+                    initial_base=Decimal(str(p.initial_inventory_base)),
+                    initial_quote=Decimal(str(p.initial_inventory_quote)),
+                ),
+                "last_mid": None,
+                "active_buy": None,
+                "active_sell": None,
+            }
+
+        self._lock = asyncio.Lock()
+        self._decimals = _env_token_decimals()
+
+    def on_match_outcomes(self, outcomes: list[dict], orderbook: OrderBook) -> None:
+        if not self._wallet_lower:
+            return
+        for raw in outcomes:
+            mid_id = raw.get("maker_order_id")
+            tid_id = raw.get("taker_order_id")
+            if not mid_id or not tid_id:
+                continue
+            maker_o = orderbook.get(mid_id)
+            taker_o = orderbook.get(tid_id)
+            try:
+                m_fill = Decimal(str(raw.get("maker_fill_amount", "0")))
+                t_fill = Decimal(str(raw.get("taker_fill_amount", "0")))
+            except Exception:
+                continue
+            if m_fill <= 0 or t_fill <= 0:
+                continue
+            if taker_o and taker_o.wallet_address.lower() == self._wallet_lower:
+                st = self._pair_states.get(taker_o.token_pair)
+                if st:
+                    st["inventory"].apply_mm_buy(m_fill, t_fill)
+                    logger.info("MM 체결(매수): +base=%s -quote=%s", m_fill, t_fill)
+            if maker_o and maker_o.wallet_address.lower() == self._wallet_lower:
+                st = self._pair_states.get(maker_o.token_pair)
+                if st:
+                    st["inventory"].apply_mm_sell(m_fill, t_fill)
+                    logger.info("MM 체결(매도): -base=%s +quote=%s", m_fill, t_fill)
+
+    async def run_forever(self) -> None:
+        self._running = True
+        logger.info("MM 봇 시작 wallet=%s onchain=%s", self._wallet or "(none)", self._escrow.enabled)
+        while self._running:
+            try:
+                for pair in self._cfg.pairs:
+                    await self._tick_pair(pair.token_pair)
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                logger.exception("MM 봇 틱 실패")
+            await asyncio.sleep(self._refresh_sec)
+        logger.info("MM 봇 종료")
+
+    def stop(self) -> None:
+        self._running = False
+
+    async def _tick_pair(self, token_pair: str) -> None:
+        st = self._pair_states.get(token_pair)
+        if st is None:
+            return
+
+        res = await self._price_feed.get_mid_price(token_pair)
+        now = wall_time()
+
+        if res.mid is None:
+            self._risk.mark_feed_failed(True)
+            async with self._lock:
+                await self._cancel_all_mm_orders(token_pair)
+            return
+
+        self._risk.mark_feed_failed(False)
+        mid = res.mid
+        self._risk.record_price(now, mid)
+        self._spread_calc.record_mid(now, mid)
+
+        if not self._risk.can_quote(now):
+            async with self._lock:
+                await self._cancel_all_mm_orders(token_pair)
+            return
+
+        inv: InventoryState = st["inventory"]
+        spread_bps = self._spread_calc.effective_spread_bps()
+        bid_px, ask_px = bid_ask_prices(mid, spread_bps)
+
+        st["last_mid"] = mid
+
+        can_bid = self._risk.can_quote_bid(inv, Decimal(str(mid)))
+        can_ask = self._risk.can_quote_ask(inv, Decimal(str(mid)))
+
+        async with self._lock:
+            await self._refresh_quotes(token_pair, bid_px, ask_px, can_bid, can_ask)
+
+    async def _cancel_all_mm_orders(self, token_pair: str) -> None:
+        st = self._pair_states[token_pair]
+        for key in ("active_buy", "active_sell"):
+            oid = st.get(key)
+            if oid:
+                await self._safe_cancel_order(oid)
+                st[key] = None
+
+    async def _safe_cancel_order(self, order_id: str) -> None:
+        for attempt in range(3):
+            try:
+                if self._escrow.enabled:
+                    txh = await asyncio.to_thread(self._escrow.cancel_order, order_id)
+                    if txh is None and attempt < 2:
+                        await asyncio.sleep(1.0)
+                        continue
+                o = self._orderbook.get(order_id)
+                if o and o.is_active:
+                    try:
+                        self._orderbook.cancel(order_id)
+                    except (KeyError, ValueError):
+                        pass
+                return
+            except Exception:
+                logger.exception("MM 주문 취소 실패 order=%s attempt=%s", order_id[:8], attempt + 1)
+                await asyncio.sleep(0.5)
+
+    async def _refresh_quotes(
+        self,
+        token_pair: str,
+        bid_px: Decimal,
+        ask_px: Decimal,
+        can_bid: bool,
+        can_ask: bool,
+    ) -> None:
+        st = self._pair_states[token_pair]
+        await self._cancel_all_mm_orders(token_pair)
+
+        addr = self._wallet
+        if not addr:
+            logger.warning("MM_BOT_PRIVATE_KEY 없음 — 봇이 호가를 내지 않습니다.")
+            return
+
+        size = self._default_size
+
+        if can_bid:
+            buy_id = uuid.uuid4().hex
+            usdt_amt = size * bid_px
+            wei_q = decimal_to_wei(usdt_amt, self._decimals)
+            txh = None
+            for _ in range(3):
+                txh = await asyncio.to_thread(
+                    self._escrow.deposit, buy_id, self._quote_token, wei_q
+                )
+                if txh:
+                    break
+                await asyncio.sleep(0.8)
+            if not txh:
+                logger.error("MM 매수 예치 실패 — 비드 생략")
+            else:
+                buy = Order(
+                    order_id=buy_id,
+                    token_pair=token_pair,
+                    side="buy",
+                    amount=size,
+                    limit_price=bid_px,
+                    wallet_address=addr,
+                )
+                self._orderbook.add(buy)
+                st["active_buy"] = buy_id
+
+        if can_ask:
+            sell_id = uuid.uuid4().hex
+            wei_b = decimal_to_wei(size, self._decimals)
+            txh = None
+            for _ in range(3):
+                txh = await asyncio.to_thread(
+                    self._escrow.deposit, sell_id, self._base_token, wei_b
+                )
+                if txh:
+                    break
+                await asyncio.sleep(0.8)
+            if not txh:
+                logger.error("MM 매도 예치 실패 — 애스크 생략")
+            else:
+                sell = Order(
+                    order_id=sell_id,
+                    token_pair=token_pair,
+                    side="sell",
+                    amount=size,
+                    limit_price=ask_px,
+                    wallet_address=addr,
+                )
+                self._orderbook.add(sell)
+                st["active_sell"] = sell_id
+
+        await run_matching_cycle(self._orderbook, token_pair, self._ws, mm_bot=self)

--- a/apps/engine/src/mm_bot/config.py
+++ b/apps/engine/src/mm_bot/config.py
@@ -55,42 +55,65 @@ def load_mm_settings(path: Path | None = None) -> MMSettings:
         return MMSettings(enabled=False)
 
     try:
-        raw = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+        raw = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
     except Exception:
         logger.exception("mm_config.yaml 파싱 실패 — MM 봇 비활성")
         return MMSettings(enabled=False)
 
-    mm = raw.get("mm_bot") or {}
-    if not mm.get("enabled", False):
+    if not isinstance(raw, dict):
+        logger.warning("mm_config.yaml 루트가 매핑이 아님 — MM 봇 비활성")
         return MMSettings(enabled=False)
 
-    pairs_raw = mm.get("pairs") or []
-    pairs: list[MMPairConfig] = []
-    for p in pairs_raw:
-        if not isinstance(p, dict):
-            continue
-        tp = (p.get("token_pair") or f"{p.get('base', 'BNB')}/{p.get('quote', 'USDT')}").strip()
-        pairs.append(
-            MMPairConfig(
-                token_pair=tp,
-                initial_inventory_base=float(p.get("initial_inventory_base", 1000)),
-                initial_inventory_quote=float(p.get("initial_inventory_quote", 300_000)),
-            )
-        )
+    mm = raw.get("mm_bot")
+    if not isinstance(mm, dict):
+        logger.info("mm_config.yaml 에 mm_bot 섹션 없음 — MM 봇 비활성")
+        return MMSettings(enabled=False)
 
-    oc = mm.get("onchain") or {}
+    if not bool(mm.get("enabled", False)):
+        return MMSettings(enabled=False)
+
+    def _as_dict(v: Any) -> dict[str, Any]:
+        return v if isinstance(v, dict) else {}
+
+    pairs_raw = mm.get("pairs")
+    pairs: list[MMPairConfig] = []
+    if isinstance(pairs_raw, list):
+        for p in pairs_raw:
+            if not isinstance(p, dict):
+                continue
+            tp_raw = p.get("token_pair") or f"{p.get('base', 'BNB')}/{p.get('quote', 'USDT')}"
+            tp = str(tp_raw).strip()
+            try:
+                init_base = float(p.get("initial_inventory_base", 1000))
+                init_quote = float(p.get("initial_inventory_quote", 300_000))
+            except (TypeError, ValueError):
+                logger.warning("mm_config pair 재고 값 파싱 실패 — 기본값 사용: %s", tp)
+                init_base, init_quote = 1000.0, 300_000.0
+            pairs.append(
+                MMPairConfig(
+                    token_pair=tp,
+                    initial_inventory_base=init_base,
+                    initial_inventory_quote=init_quote,
+                )
+            )
+
+    oc = _as_dict(mm.get("onchain"))
+    try:
+        gas_gwei = int(oc.get("gas_price_gwei", 10))
+    except (TypeError, ValueError):
+        gas_gwei = 10
     onchain = MMOnchainConfig(
         base_token=str(oc.get("base_token", "")).strip(),
         quote_token=str(oc.get("quote_token", "")).strip(),
-        gas_price_gwei=int(oc.get("gas_price_gwei", 10)),
+        gas_price_gwei=gas_gwei,
     )
 
     return MMSettings(
         enabled=True,
         pairs=pairs or [MMPairConfig(token_pair="BNB/USDT")],
-        pricing=mm.get("pricing") or {},
-        spread=mm.get("spread") or {},
-        risk=mm.get("risk") or {},
-        order=mm.get("order") or {},
+        pricing=_as_dict(mm.get("pricing")),
+        spread=_as_dict(mm.get("spread")),
+        risk=_as_dict(mm.get("risk")),
+        order=_as_dict(mm.get("order")),
         onchain=onchain,
     )

--- a/apps/engine/src/mm_bot/config.py
+++ b/apps/engine/src/mm_bot/config.py
@@ -1,0 +1,96 @@
+"""mm_config.yaml 로드."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MMOnchainConfig:
+    base_token: str
+    quote_token: str
+    gas_price_gwei: int = 10
+
+
+@dataclass
+class MMPairConfig:
+    token_pair: str
+    initial_inventory_base: float = 1000.0
+    initial_inventory_quote: float = 300_000.0
+
+
+@dataclass
+class MMSettings:
+    enabled: bool = False
+    pairs: list[MMPairConfig] = field(default_factory=list)
+    pricing: dict[str, Any] = field(default_factory=dict)
+    spread: dict[str, Any] = field(default_factory=dict)
+    risk: dict[str, Any] = field(default_factory=dict)
+    order: dict[str, Any] = field(default_factory=dict)
+    onchain: MMOnchainConfig | None = None
+
+
+def _default_config_path() -> Path:
+    return Path(__file__).resolve().parents[2] / "mm_config.yaml"
+
+
+def load_mm_settings(path: Path | None = None) -> MMSettings:
+    if yaml is None:
+        logger.warning("PyYAML 미설치 — MM 봇 비활성 (uv sync 로 pyyaml 설치)")
+        return MMSettings(enabled=False)
+
+    cfg_path = path or _default_config_path()
+    if not cfg_path.is_file():
+        logger.info("mm_config.yaml 없음 — MM 봇 비활성: %s", cfg_path)
+        return MMSettings(enabled=False)
+
+    try:
+        raw = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        logger.exception("mm_config.yaml 파싱 실패 — MM 봇 비활성")
+        return MMSettings(enabled=False)
+
+    mm = raw.get("mm_bot") or {}
+    if not mm.get("enabled", False):
+        return MMSettings(enabled=False)
+
+    pairs_raw = mm.get("pairs") or []
+    pairs: list[MMPairConfig] = []
+    for p in pairs_raw:
+        if not isinstance(p, dict):
+            continue
+        tp = (p.get("token_pair") or f"{p.get('base', 'BNB')}/{p.get('quote', 'USDT')}").strip()
+        pairs.append(
+            MMPairConfig(
+                token_pair=tp,
+                initial_inventory_base=float(p.get("initial_inventory_base", 1000)),
+                initial_inventory_quote=float(p.get("initial_inventory_quote", 300_000)),
+            )
+        )
+
+    oc = mm.get("onchain") or {}
+    onchain = MMOnchainConfig(
+        base_token=str(oc.get("base_token", "")).strip(),
+        quote_token=str(oc.get("quote_token", "")).strip(),
+        gas_price_gwei=int(oc.get("gas_price_gwei", 10)),
+    )
+
+    return MMSettings(
+        enabled=True,
+        pairs=pairs or [MMPairConfig(token_pair="BNB/USDT")],
+        pricing=mm.get("pricing") or {},
+        spread=mm.get("spread") or {},
+        risk=mm.get("risk") or {},
+        order=mm.get("order") or {},
+        onchain=onchain,
+    )

--- a/apps/engine/src/mm_bot/escrow_client.py
+++ b/apps/engine/src/mm_bot/escrow_client.py
@@ -73,7 +73,12 @@ class MMEscrowClient:
         return Account.from_key(self._pk).address
 
     def _w3(self) -> Web3:
-        return Web3(Web3.HTTPProvider(BSC_TESTNET_RPC, request_kwargs={"timeout": _RPC_TIMEOUT_SEC}))
+        return Web3(
+            Web3.HTTPProvider(
+                BSC_TESTNET_RPC,
+                request_kwargs={"timeout": _RPC_TIMEOUT_SEC},
+            )
+        )
 
     def _sign_and_send(self, tx: dict) -> str | None:
         assert self._pk is not None

--- a/apps/engine/src/mm_bot/escrow_client.py
+++ b/apps/engine/src/mm_bot/escrow_client.py
@@ -70,7 +70,16 @@ class MMEscrowClient:
     def address(self) -> str | None:
         if not self._pk:
             return None
-        return Account.from_key(self._pk).address
+        # eth_account 는 malformed key 에 ValueError/binascii.Error 등 다양한
+        # 예외를 내므로 포괄 방어. 오타 하나로 엔진 부팅이 실패하면 안 된다.
+        try:
+            return Account.from_key(self._pk).address
+        except Exception as e:
+            logger.error(
+                "MM_BOT_PRIVATE_KEY 가 malformed — 지갑 주소 복원 실패: %s",
+                e,
+            )
+            return None
 
     def _w3(self) -> Web3:
         return Web3(

--- a/apps/engine/src/mm_bot/escrow_client.py
+++ b/apps/engine/src/mm_bot/escrow_client.py
@@ -1,0 +1,171 @@
+"""MM 지갑 — ERC20 approve / Escrow deposit·cancel (web3.py)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from decimal import ROUND_DOWN, Decimal
+
+from eth_account import Account
+from web3 import Web3
+
+from src.config import BSC_CHAIN_ID, BSC_TESTNET_RPC, ESCROW_CONTRACT_ADDRESS
+from src.signer.hash_builder import to_bytes32
+from src.signer.submitter import DARKPOOL_ESCROW_ABI
+
+logger = logging.getLogger(__name__)
+
+_RPC_TIMEOUT_SEC = 30
+
+ERC20_MIN_ABI = [
+    {
+        "name": "approve",
+        "type": "function",
+        "inputs": [
+            {"name": "spender", "type": "address"},
+            {"name": "amount", "type": "uint256"},
+        ],
+        "outputs": [{"type": "bool"}],
+        "stateMutability": "nonpayable",
+    },
+    {
+        "name": "allowance",
+        "type": "function",
+        "inputs": [
+            {"name": "owner", "type": "address"},
+            {"name": "spender", "type": "address"},
+        ],
+        "outputs": [{"type": "uint256"}],
+        "stateMutability": "view",
+    },
+]
+
+
+def decimal_to_wei(amount: Decimal, decimals: int) -> int:
+    scale = Decimal(10) ** decimals
+    return int((amount * scale).quantize(Decimal(1), rounding=ROUND_DOWN))
+
+
+class MMEscrowClient:
+    def __init__(
+        self,
+        *,
+        private_key: str | None,
+        gas_price_gwei: int = 10,
+        dry_run: bool = False,
+    ) -> None:
+        self._pk = (private_key or "").strip() or None
+        self._gas_gwei = gas_price_gwei
+        self._dry_run = dry_run or os.environ.get("MM_BOT_DRY_RUN", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self._pk) and bool(ESCROW_CONTRACT_ADDRESS) and not self._dry_run
+
+    @property
+    def address(self) -> str | None:
+        if not self._pk:
+            return None
+        return Account.from_key(self._pk).address
+
+    def _w3(self) -> Web3:
+        return Web3(Web3.HTTPProvider(BSC_TESTNET_RPC, request_kwargs={"timeout": _RPC_TIMEOUT_SEC}))
+
+    def _sign_and_send(self, tx: dict) -> str | None:
+        assert self._pk is not None
+        w3 = self._w3()
+        signed = w3.eth.account.sign_transaction(tx, self._pk)
+        h = w3.eth.send_raw_transaction(signed.raw_transaction)
+        rx = w3.eth.wait_for_transaction_receipt(h, timeout=120)
+        if rx.get("status") != 1:
+            logger.error("MM on-chain tx 실패: %s", h.hex())
+            return None
+        return h.hex()
+
+    def ensure_allowance(self, token: str, spender: str, need: int) -> bool:
+        if not self.enabled:
+            return True
+        assert self._pk is not None
+        w3 = self._w3()
+        acct = Account.from_key(self._pk)
+        c = w3.eth.contract(address=Web3.to_checksum_address(token), abi=ERC20_MIN_ABI)
+        cur = c.functions.allowance(acct.address, Web3.to_checksum_address(spender)).call()
+        if cur >= need:
+            return True
+
+        nonce = w3.eth.get_transaction_count(Web3.to_checksum_address(acct.address))
+        tx = c.functions.approve(Web3.to_checksum_address(spender), 2**256 - 1).build_transaction(
+            {
+                "chainId": BSC_CHAIN_ID,
+                "from": acct.address,
+                "nonce": nonce,
+                "gas": 100_000,
+                "gasPrice": w3.to_wei(self._gas_gwei, "gwei"),
+            }
+        )
+        return self._sign_and_send(tx) is not None
+
+    def deposit(self, order_id_hex: str, token: str, amount_wei: int) -> str | None:
+        if self._dry_run or not self._pk:
+            logger.info("MM deposit 스킵 (dry-run 또는 키 없음) order=%s", order_id_hex[:8])
+            return "dry-run"
+
+        if not ESCROW_CONTRACT_ADDRESS:
+            logger.warning("ESCROW_CONTRACT_ADDRESS 미설정 — MM deposit 스킵")
+            return None
+
+        if not self.ensure_allowance(token, ESCROW_CONTRACT_ADDRESS, amount_wei):
+            logger.error("MM approve 실패 token=%s", token[:10])
+            return None
+
+        w3 = self._w3()
+        acct = Account.from_key(self._pk)
+        esc = w3.eth.contract(
+            address=Web3.to_checksum_address(ESCROW_CONTRACT_ADDRESS),
+            abi=DARKPOOL_ESCROW_ABI,
+        )
+        oid = to_bytes32(order_id_hex)
+        nonce = w3.eth.get_transaction_count(Web3.to_checksum_address(acct.address))
+        tx = esc.functions.deposit(
+            oid,
+            Web3.to_checksum_address(token),
+            amount_wei,
+        ).build_transaction(
+            {
+                "chainId": BSC_CHAIN_ID,
+                "from": acct.address,
+                "nonce": nonce,
+                "gas": 350_000,
+                "gasPrice": w3.to_wei(self._gas_gwei, "gwei"),
+            }
+        )
+        return self._sign_and_send(tx)
+
+    def cancel_order(self, order_id_hex: str) -> str | None:
+        if self._dry_run or not self._pk:
+            return "dry-run"
+        if not ESCROW_CONTRACT_ADDRESS:
+            return None
+
+        w3 = self._w3()
+        acct = Account.from_key(self._pk)
+        esc = w3.eth.contract(
+            address=Web3.to_checksum_address(ESCROW_CONTRACT_ADDRESS),
+            abi=DARKPOOL_ESCROW_ABI,
+        )
+        oid = to_bytes32(order_id_hex)
+        nonce = w3.eth.get_transaction_count(Web3.to_checksum_address(acct.address))
+        tx = esc.functions.cancelOrder(oid).build_transaction(
+            {
+                "chainId": BSC_CHAIN_ID,
+                "from": acct.address,
+                "nonce": nonce,
+                "gas": 250_000,
+                "gasPrice": w3.to_wei(self._gas_gwei, "gwei"),
+            }
+        )
+        return self._sign_and_send(tx)

--- a/apps/engine/src/mm_bot/inventory.py
+++ b/apps/engine/src/mm_bot/inventory.py
@@ -1,0 +1,38 @@
+"""봇 가상 재고 (테스트넷 데모용)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+
+@dataclass
+class InventoryState:
+    initial_base: Decimal
+    initial_quote: Decimal
+    base: Decimal = field(init=False)
+    quote: Decimal = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.base = self.initial_base
+        self.quote = self.initial_quote
+
+    def base_value_usd(self, mid: Decimal) -> Decimal:
+        return self.base * mid
+
+    def total_notional_usd(self, mid: Decimal) -> Decimal:
+        return self.base * mid + self.quote
+
+    def base_share(self, mid: Decimal) -> float:
+        t = self.total_notional_usd(mid)
+        if t <= 0:
+            return 0.5
+        return float((self.base * mid) / t)
+
+    def apply_mm_buy(self, base_received: Decimal, quote_paid: Decimal) -> None:
+        self.base += base_received
+        self.quote -= quote_paid
+
+    def apply_mm_sell(self, base_sold: Decimal, quote_received: Decimal) -> None:
+        self.base -= base_sold
+        self.quote += quote_received

--- a/apps/engine/src/mm_bot/order_gen.py
+++ b/apps/engine/src/mm_bot/order_gen.py
@@ -1,0 +1,14 @@
+"""호가 가격 산출."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+
+def bid_ask_prices(mid: float, spread_bps: float) -> tuple[Decimal, Decimal]:
+    """bid = mid * (1 - spread/2), ask = mid * (1 + spread/2). spread_bps 총폭."""
+    sf = spread_bps / 10_000.0
+    m = Decimal(str(mid))
+    bid = m * (Decimal(1) - Decimal(str(sf)) / Decimal(2))
+    ask = m * (Decimal(1) + Decimal(str(sf)) / Decimal(2))
+    return bid, ask

--- a/apps/engine/src/mm_bot/price_feed.py
+++ b/apps/engine/src/mm_bot/price_feed.py
@@ -1,0 +1,105 @@
+"""PancakeSwap + Binance 가중 평균, 이상치 시 단일 소스."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+
+from src.pricing.binance import fetch_binance_price
+from src.pricing.pancakeswap import fetch_pancakeswap_price
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MidPriceResult:
+    mid: float | None
+    pancake: float | None
+    binance: float | None
+    outlier_downgraded: bool
+    error: str | None = None
+
+
+class PriceFeedListener:
+    """스펙: Pancake 60% + Binance 40%, 편차 > threshold 시 한 소스 제외."""
+
+    def __init__(
+        self,
+        *,
+        pancake_weight: float = 0.6,
+        binance_weight: float = 0.4,
+        outlier_threshold_pct: float = 2.0,
+        outlier_primary: str = "binance",
+    ) -> None:
+        self._wp = pancake_weight
+        self._wb = binance_weight
+        self._threshold = outlier_threshold_pct
+        self._primary = outlier_primary if outlier_primary in ("binance", "pancake") else "binance"
+
+    async def get_mid_price(self, token_pair: str) -> MidPriceResult:
+        pancake, binance = await asyncio.gather(
+            fetch_pancakeswap_price(token_pair),
+            fetch_binance_price(token_pair),
+        )
+
+        if pancake is None and binance is None:
+            return MidPriceResult(
+                mid=None,
+                pancake=None,
+                binance=None,
+                outlier_downgraded=False,
+                error="all feeds failed",
+            )
+
+        if pancake is not None and binance is not None:
+            spread = abs(pancake - binance)
+            lo = min(pancake, binance)
+            diff_pct = (spread / lo * 100.0) if lo > 0 else 0.0
+            if diff_pct > self._threshold:
+                chosen = binance if self._primary == "binance" else pancake
+                logger.warning(
+                    "MM price feed: outlier %.2f%% > %.2f%%, using %s only",
+                    diff_pct,
+                    self._threshold,
+                    self._primary,
+                )
+                return MidPriceResult(
+                    mid=chosen,
+                    pancake=pancake,
+                    binance=binance,
+                    outlier_downgraded=True,
+                    error=None,
+                )
+            mid = pancake * self._wp + binance * self._wb
+            return MidPriceResult(
+                mid=mid,
+                pancake=pancake,
+                binance=binance,
+                outlier_downgraded=False,
+                error=None,
+            )
+
+        if pancake is not None:
+            return MidPriceResult(
+                mid=pancake,
+                pancake=pancake,
+                binance=None,
+                outlier_downgraded=False,
+                error=None,
+            )
+        return MidPriceResult(
+            mid=binance,
+            pancake=None,
+            binance=binance,
+            outlier_downgraded=False,
+            error=None,
+        )
+
+    async def poll_loop_sleep(self, interval_sec: float) -> None:
+        await asyncio.sleep(interval_sec)
+
+
+def wall_time() -> float:
+    return time.monotonic()

--- a/apps/engine/src/mm_bot/risk.py
+++ b/apps/engine/src/mm_bot/risk.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import deque
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import TYPE_CHECKING, Deque, Tuple
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from src.mm_bot.inventory import InventoryState
@@ -25,7 +25,7 @@ class RiskController:
 
     def __init__(self, cfg: RiskConfig) -> None:
         self._cfg = cfg
-        self._prices: Deque[Tuple[float, float]] = deque()
+        self._prices: deque[tuple[float, float]] = deque()
         self._feed_failed = False
         self._paused_until: float = 0.0
 

--- a/apps/engine/src/mm_bot/risk.py
+++ b/apps/engine/src/mm_bot/risk.py
@@ -1,0 +1,76 @@
+"""가격 급변, 피드 실패, 재고·노출 한도."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import TYPE_CHECKING, Deque, Tuple
+
+if TYPE_CHECKING:
+    from src.mm_bot.inventory import InventoryState
+
+
+@dataclass
+class RiskConfig:
+    max_exposure_pct: float = 70.0
+    rebalance_threshold_pct: float = 60.0
+    price_shock_pct: float = 5.0
+    price_shock_window_sec: float = 60.0
+    min_inventory_pct: float = 5.0
+
+
+class RiskController:
+    """베이스 비중이 70% 넘으면 비드 중단, 30% 미만이면 애스크 중단(대칭)."""
+
+    def __init__(self, cfg: RiskConfig) -> None:
+        self._cfg = cfg
+        self._prices: Deque[Tuple[float, float]] = deque()
+        self._feed_failed = False
+        self._paused_until: float = 0.0
+
+    def mark_feed_failed(self, failed: bool) -> None:
+        self._feed_failed = failed
+
+    def record_price(self, now: float, mid: float) -> None:
+        self._prices.append((now, mid))
+        cutoff = now - self._cfg.price_shock_window_sec
+        while self._prices and self._prices[0][0] < cutoff:
+            self._prices.popleft()
+
+        if len(self._prices) >= 2:
+            oldest = self._prices[0][1]
+            if oldest > 0:
+                change_pct = abs(mid - oldest) / oldest * 100.0
+                if change_pct >= self._cfg.price_shock_pct:
+                    self._paused_until = now + float(self._cfg.price_shock_window_sec)
+
+    def is_shock_paused(self, now: float) -> bool:
+        return now < self._paused_until
+
+    def can_quote(self, now: float) -> bool:
+        if self._feed_failed:
+            return False
+        return not self.is_shock_paused(now)
+
+    def can_quote_bid(self, inv: InventoryState, mid: Decimal) -> bool:
+        if inv.initial_quote <= 0:
+            return True
+        min_q = inv.initial_quote * Decimal(str(self._cfg.min_inventory_pct / 100.0))
+        if inv.quote < min_q:
+            return False
+        hi = self._cfg.max_exposure_pct / 100.0
+        if inv.base_share(mid) > hi:
+            return False
+        return True
+
+    def can_quote_ask(self, inv: InventoryState, mid: Decimal) -> bool:
+        if inv.initial_base <= 0:
+            return True
+        min_b = inv.initial_base * Decimal(str(self._cfg.min_inventory_pct / 100.0))
+        if inv.base < min_b:
+            return False
+        lo = 1.0 - self._cfg.max_exposure_pct / 100.0
+        if inv.base_share(mid) < lo:
+            return False
+        return True

--- a/apps/engine/src/mm_bot/spread.py
+++ b/apps/engine/src/mm_bot/spread.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import dataclass
-from typing import Deque, Tuple
 
 
 @dataclass
@@ -21,7 +20,7 @@ class SpreadCalculator:
 
     def __init__(self, cfg: SpreadConfig) -> None:
         self._cfg = cfg
-        self._history: Deque[Tuple[float, float]] = deque()
+        self._history: deque[tuple[float, float]] = deque()
 
     def record_mid(self, now: float, mid: float) -> None:
         self._history.append((now, mid))

--- a/apps/engine/src/mm_bot/spread.py
+++ b/apps/engine/src/mm_bot/spread.py
@@ -1,0 +1,48 @@
+"""동적 스프레드: 기본 bps × 변동성 배수, 상·하한."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, Tuple
+
+
+@dataclass
+class SpreadConfig:
+    base_bps: float = 30.0
+    min_bps: float = 10.0
+    max_bps: float = 200.0
+    vol_window_sec: float = 60.0
+    vol_multiplier_max: float = 3.0
+
+
+class SpreadCalculator:
+    """effective_spread_bps = clamp(base_bps * vol_mult, min, max)."""
+
+    def __init__(self, cfg: SpreadConfig) -> None:
+        self._cfg = cfg
+        self._history: Deque[Tuple[float, float]] = deque()
+
+    def record_mid(self, now: float, mid: float) -> None:
+        self._history.append((now, mid))
+        cutoff = now - self._cfg.vol_window_sec
+        while self._history and self._history[0][0] < cutoff:
+            self._history.popleft()
+
+    def volatility_multiplier(self) -> float:
+        if len(self._history) < 2:
+            return 1.0
+        mids = [m for _, m in self._history]
+        hi, lo = max(mids), min(mids)
+        ref = sum(mids) / len(mids)
+        if ref <= 0:
+            return 1.0
+        range_pct = (hi - lo) / ref * 100.0
+        # 0% 변동 → 1.0, 약 2% 레인지에서 3.0 근처까지 선형
+        extra = min(2.0, range_pct)
+        mult = 1.0 + extra
+        return min(self._cfg.vol_multiplier_max, mult)
+
+    def effective_spread_bps(self) -> float:
+        raw = self._cfg.base_bps * self.volatility_multiplier()
+        return max(self._cfg.min_bps, min(self._cfg.max_bps, raw))

--- a/apps/engine/src/routes.py
+++ b/apps/engine/src/routes.py
@@ -6,10 +6,9 @@ import uuid
 
 from fastapi import APIRouter, HTTPException, Request, WebSocket, WebSocketDisconnect
 
-from src.matching.engine import MatchingEngine
+from src.matching.runner import run_matching_cycle
 from src.models import Order, OrderBook
 from src.schemas import OrderCreateRequest, OrderResponse
-from src.signer.pipeline import process_match_results
 from src.ws import ConnectionManager
 
 logger = logging.getLogger(__name__)
@@ -36,38 +35,6 @@ def _order_to_response(order: Order) -> OrderResponse:
     )
 
 
-async def _run_matching_cycle(
-    orderbook: OrderBook,
-    token_pair: str,
-    ws_manager: ConnectionManager,
-) -> None:
-    """백그라운드 매칭 사이클: 매칭 → 서명 → 제출 → WS 알림."""
-    try:
-        engine = MatchingEngine(orderbook)
-        results = await engine.run_matching_cycle(token_pair)
-        if not results:
-            return
-
-        # 서명 + BSC 제출
-        outcomes = await asyncio.to_thread(process_match_results, results)
-
-        # WS 체결 알림
-        await ws_manager.broadcast({"action": "matched", "results": outcomes})
-
-        # 서명/제출 결과 로깅
-        submitted = [o for o in outcomes if o.get("tx_hash")]
-        if submitted:
-            logger.info(
-                "매칭 사이클 완료: %d건 체결, %d건 BSC 제출",
-                len(results),
-                len(submitted),
-            )
-        else:
-            logger.info("매칭 사이클 완료: %d건 체결 (BSC 미설정)", len(results))
-    except Exception:
-        logger.exception("매칭 사이클 실패: token_pair=%s", token_pair)
-
-
 @router.post("/order", response_model=OrderResponse, status_code=201)
 async def create_order(body: OrderCreateRequest, request: Request) -> OrderResponse:
     """주문 생성. order_id는 서버에서 uuid4로 생성. 생성 후 매칭 사이클 자동 실행."""
@@ -89,9 +56,9 @@ async def create_order(body: OrderCreateRequest, request: Request) -> OrderRespo
     except Exception:
         logger.exception("broadcast 실패 (created, order_id=%s)", order_id)
 
-    # 백그라운드 매칭 사이클 실행 (태스크 추적)
+    mm_bot = getattr(request.app.state, "mm_bot", None)
     task = asyncio.create_task(
-        _run_matching_cycle(orderbook, body.token_pair, manager)
+        run_matching_cycle(orderbook, body.token_pair, manager, mm_bot=mm_bot)
     )
     bg_tasks: set = getattr(request.app.state, "background_tasks", None) or set()
     request.app.state.background_tasks = bg_tasks

--- a/apps/engine/tests/test_mm_bot.py
+++ b/apps/engine/tests/test_mm_bot.py
@@ -15,12 +15,16 @@ def test_bid_ask_symmetric_spread() -> None:
 
 
 def test_spread_volatility_increases_bps() -> None:
+    base_bps = 30.0
     calc = SpreadCalculator(
-        SpreadConfig(base_bps=30.0, min_bps=10.0, max_bps=200.0, vol_window_sec=60.0)
+        SpreadConfig(base_bps=base_bps, min_bps=10.0, max_bps=200.0, vol_window_sec=60.0)
     )
+    # hi=101, lo=99, range≈2% → multiplier≈3.0 → effective≈90bps
     t = 0.0
     for p in (100.0, 100.5, 101.0, 99.0, 100.0):
         t += 1.0
         calc.record_mid(t, p)
     eff = calc.effective_spread_bps()
-    assert eff >= 30.0
+    # 변동성 승수가 실제로 작동했는지 확인 — base_bps 보다 엄격히 커야 한다.
+    assert eff > base_bps
+    assert eff >= base_bps * 2.0

--- a/apps/engine/tests/test_mm_bot.py
+++ b/apps/engine/tests/test_mm_bot.py
@@ -1,0 +1,26 @@
+"""MM 봇 유닛 테스트 (가격 피드 없이 순수 로직)."""
+
+from decimal import Decimal
+
+from src.mm_bot.order_gen import bid_ask_prices
+from src.mm_bot.spread import SpreadCalculator, SpreadConfig
+
+
+def test_bid_ask_symmetric_spread() -> None:
+    bid, ask = bid_ask_prices(600.0, 100.0)
+    assert bid < Decimal("600")
+    assert ask > Decimal("600")
+    mid = (bid + ask) / 2
+    assert abs(mid - Decimal("600")) < Decimal("0.01")
+
+
+def test_spread_volatility_increases_bps() -> None:
+    calc = SpreadCalculator(
+        SpreadConfig(base_bps=30.0, min_bps=10.0, max_bps=200.0, vol_window_sec=60.0)
+    )
+    t = 0.0
+    for p in (100.0, 100.5, 101.0, 99.0, 100.0):
+        t += 1.0
+        calc.record_mid(t, p)
+    eff = calc.effective_spread_bps()
+    assert eff >= 30.0

--- a/apps/engine/uv.lock
+++ b/apps/engine/uv.lock
@@ -305,6 +305,7 @@ dependencies = [
     { name = "httpx" },
     { name = "openai" },
     { name = "pydantic" },
+    { name = "pyyaml" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "web3" },
 ]
@@ -322,6 +323,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27,<1.0" },
     { name = "openai", specifier = ">=1.30,<2.0" },
     { name = "pydantic", specifier = ">=2.7,<3.0" },
+    { name = "pyyaml", specifier = ">=6.0,<7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34,<1.0" },
     { name = "web3", specifier = ">=7.0,<8.0" },
 ]


### PR DESCRIPTION
## 요약

Closes #17

BuidlHack 2026 트랙 A (testnet demo) 용 AI Market Maker 를 \`apps/engine\` 에 추가한다. 오더북이 텅 비면 매칭 자체가 일어나지 않으므로 BSC 테스트넷에서 양방향 호가를 상시 유지하는 MM 봇이 필요하다.

## 변경 사항

### \`src/mm_bot/\` 패키지 신설 (8개 모듈)
- \`bot.py\` — 메인 tick 루프, 양방향 호가 갱신, on_match_outcomes 훅으로 재고 업데이트
- \`config.py\` — \`mm_config.yaml\` 로드 (PyYAML 미설치/파일 없음 시 enabled=false graceful degrade)
- \`price_feed.py\` — Pancake+Binance asyncio.gather, 편차 threshold 초과 시 primary 소스만 사용
- \`spread.py\` — 변동성 창 기반 multiplier, min/max clamp
- \`risk.py\` — 피드 실패, 가격 쇼크 일시정지, 재고 최소비율·노출 한도
- \`inventory.py\` — base/quote decimal 재고, MM 매수/매도 적용
- \`order_gen.py\` — 대칭 spread 기반 bid/ask 산출
- \`escrow_client.py\` — ERC20 approve, Escrow deposit/cancelOrder, dry-run 플래그

### 엔진 통합
- \`src/matching/runner.py\` 신설 — 기존 routes 인라인 매칭 사이클을 공용 함수로 추출, MM 봇 outcome 훅 연결
- \`src/routes.py\` — \`run_matching_cycle\` 사용, \`app.state.mm_bot\` 참조
- \`src/main.py\` lifespan — MM 봇 태스크 등록/정리
- \`mm_config.yaml\` (기본 enabled=false), \`.env.example\` (\`MM_BOT_PRIVATE_KEY\`, \`MM_BOT_DRY_RUN\`, \`MM_TOKEN_DECIMALS\`)
- \`pyproject.toml\`: \`pyyaml>=6.0,<7.0\`

### 테스트 (\`tests/test_mm_bot.py\`)
- bid/ask 대칭성
- 변동성에 따른 effective_spread_bps 증가

### 린트 정리 (별도 커밋 a8acf28)
- bot.py: import 블록 병합·정렬 (I001), logger 줄바꿈 (E501)
- escrow_client.py: HTTPProvider 인자 줄바꿈 (E501)
- risk.py / spread.py: \`typing.Deque\`·\`Tuple\` → PEP 585 \`deque[tuple[...]]\` (UP035/UP006)

## 기술적 판단

### 스펙 v2 "aiohttp + WebSocket" vs 현재 구현 "httpx polling"

엔진의 outbound HTTP 경로 6개를 전수조사한 결과, **WS 전환 가치가 있는 경로는 Binance ticker 하나뿐**이다. Pancake subgraph (hosted subscriptions sunset), attestation·signer (one-shot·write tx) 는 전부 HTTP가 정석이다.

httpx vs aiohttp 자체는 쟁점이 아니다. 엔진 전체가 이미 httpx로 통일되어 있어 aiohttp로 갈아엎을 이유가 없고, Binance WS 는 dual HTTP stack 대신 \`websockets\` 라이브러리로 따로 올리는 게 깔끔하다.

즉 스펙과의 차이는 **spec literal mismatch 가 아니라 spec intent(\"저지연 가격 피드\")의 더 나은 재해석**이다. Binance WS 업그레이드는 #18 으로 분리했다.

(판단 근거 표·테이블 전체는 #17 의 첫 코멘트 참조)

### MM 봇 활성화 기본값 = false
\`mm_config.yaml enabled: false\` 를 기본값으로 둬서 기존 엔진 회귀 위험 0. 테스트넷 smoke test 는 \`.env\` + yaml 토글 후 수동 진행.

### 린트 fix를 같은 PR에 넣은 이유
scope 확장이 아니라 엔진 전체 린트 기준(py314, line-length 100, E/F/I/N/W/UP) 에 맞추는 작업. CodeRabbit 리뷰를 린트 11건으로 낭비시키지 않으려 함께 푸시.

## 검증

- \`uv run ruff check\` → \`All checks passed!\`
- \`uv run pytest -q\` → \`118 passed, 164 warnings in 0.84s\` (기존 116 + MM 봇 유닛 2)
- 수동 검증: \`enabled=false\` 기본값으로 엔진 부팅 시 MM 태스크 미등록 확인 (기존 동작 회귀 없음)
- 온체인 경로는 \`MM_BOT_DRY_RUN=1\` 로 지갑 없이 오더북만 테스트 가능

## 후속 작업

- #18 — Binance 가격 피드 REST polling → WebSocket bookTicker 스트림 업그레이드

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable market-maker bot with YAML settings and example env entries (dry-run, private key, token decimals)
  * Dynamic spread calculation from volatility and multi-source price aggregation with outlier protection
  * On-chain escrow support for testnet submissions (dry-run mode available)

* **Refactor**
  * Matching pipeline modularized to call the market-maker hook

* **Tests**
  * Added unit tests for pricing and spread dynamics

* **Chores**
  * Added YAML parsing dependency for config loading
<!-- end of auto-generated comment: release notes by coderabbit.ai -->