### PR TITLE
feat: Binance bookTicker WebSocket 스트림 MM 봇 가격 피드 통합

### DIFF
--- a/apps/engine/pyproject.toml
+++ b/apps/engine/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "httpx>=0.27,<1.0",
     "openai>=1.30,<2.0",
     "pyyaml>=6.0,<7.0",
+    "websockets>=13,<16",
 ]
 
 [dependency-groups]

--- a/apps/engine/src/mm_bot/bot.py
+++ b/apps/engine/src/mm_bot/bot.py
@@ -13,7 +13,7 @@ from src.matching.runner import run_matching_cycle
 from src.mm_bot.escrow_client import MMEscrowClient, decimal_to_wei
 from src.mm_bot.inventory import InventoryState
 from src.mm_bot.order_gen import bid_ask_prices
-from src.mm_bot.price_feed import PriceFeedListener, wall_time
+from src.mm_bot.price_feed import BinanceWsFeed, PriceFeedListener, wall_time
 from src.mm_bot.risk import RiskConfig, RiskController
 from src.mm_bot.spread import SpreadCalculator, SpreadConfig
 from src.models.order import Order
@@ -57,10 +57,12 @@ class MMBot:
             pw, bw = (w0 / tot, w1 / tot) if tot > 0 else (0.6, 0.4)
         else:
             pw, bw = 0.6, 0.4
+        self._binance_ws = BinanceWsFeed()
         self._price_feed = PriceFeedListener(
             pancake_weight=pw,
             binance_weight=bw,
             outlier_threshold_pct=float(pr.get("outlier_threshold_pct", 2.0)),
+            binance_ws=self._binance_ws,
         )
 
         sp = settings.spread
@@ -156,16 +158,22 @@ class MMBot:
             self._wallet or "(none)",
             self._escrow.enabled,
         )
-        while self._running:
-            try:
-                for pair in self._cfg.pairs:
-                    await self._tick_pair(pair.token_pair)
-            except asyncio.CancelledError:
-                break
-            except Exception:
-                logger.exception("MM 봇 틱 실패")
-            await asyncio.sleep(self._refresh_sec)
-        logger.info("MM 봇 종료")
+        for pair in self._cfg.pairs:
+            self._binance_ws.subscribe(pair.token_pair)
+        self._binance_ws.start()
+        try:
+            while self._running:
+                try:
+                    for pair in self._cfg.pairs:
+                        await self._tick_pair(pair.token_pair)
+                except asyncio.CancelledError:
+                    break
+                except Exception:
+                    logger.exception("MM 봇 틱 실패")
+                await asyncio.sleep(self._refresh_sec)
+        finally:
+            await self._binance_ws.stop()
+            logger.info("MM 봇 종료")
 
     def stop(self) -> None:
         self._running = False

--- a/apps/engine/src/mm_bot/price_feed.py
+++ b/apps/engine/src/mm_bot/price_feed.py
@@ -53,6 +53,10 @@ def _parse_book_ticker(raw: str | bytes) -> float | None:
         return None
     if bid <= 0 or ask <= 0:
         return None
+    # crossed top-of-book 은 Binance bookTicker 에서 발생 불가. 나왔다면
+    # corrupted payload 이므로 뒤집힌 mid 로 호가를 내지 않도록 거절.
+    if bid > ask:
+        return None
     return (bid + ask) / 2.0
 
 

--- a/apps/engine/src/mm_bot/price_feed.py
+++ b/apps/engine/src/mm_bot/price_feed.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import random
 import time
 from dataclasses import dataclass
 
@@ -148,14 +149,17 @@ class BinanceWsFeed:
             except asyncio.CancelledError:
                 break
             except Exception as e:
+                # Full jitter: [0, backoff) — thundering herd 방지 표준 관행.
+                jittered = random.random() * backoff
                 logger.warning(
-                    "BinanceWsFeed %s 연결 끊김, %.1fs 후 재시도: %s",
+                    "BinanceWsFeed %s 연결 끊김, %.2fs(jittered, cap=%.1f) 후 재시도: %s",
                     symbol,
+                    jittered,
                     backoff,
                     e,
                 )
                 try:
-                    await asyncio.sleep(backoff)
+                    await asyncio.sleep(jittered)
                 except asyncio.CancelledError:
                     break
                 backoff = min(backoff * 2.0, self._backoff_max)

--- a/apps/engine/src/mm_bot/price_feed.py
+++ b/apps/engine/src/mm_bot/price_feed.py
@@ -1,16 +1,25 @@
-"""PancakeSwap + Binance 가중 평균, 이상치 시 단일 소스."""
+"""PancakeSwap + Binance 가중 평균, 이상치 시 단일 소스.
+
+Binance 쪽은 bookTicker WebSocket 스트림(BinanceWsFeed)을 우선 경로로 쓰고,
+연결이 끊겼거나 stale 이면 기존 REST polling 으로 fallback 한다.
+"""
 
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import time
 from dataclasses import dataclass
 
-from src.pricing.binance import fetch_binance_price
+import websockets
+
+from src.pricing.binance import binance_symbol, fetch_binance_price
 from src.pricing.pancakeswap import fetch_pancakeswap_price
 
 logger = logging.getLogger(__name__)
+
+BINANCE_WS_BASE = "wss://stream.binance.com:9443/ws"
 
 
 @dataclass
@@ -20,6 +29,132 @@ class MidPriceResult:
     binance: float | None
     outlier_downgraded: bool
     error: str | None = None
+
+
+def _parse_book_ticker(raw: str | bytes) -> float | None:
+    """bookTicker 페이로드에서 (bid+ask)/2 mid 를 추출.
+
+    비-JSON / 필드 누락 / 음수 / 0 은 None (호출자가 fallback 경로로 빠지도록).
+    """
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    b = data.get("b")
+    a = data.get("a")
+    if b is None or a is None:
+        return None
+    try:
+        bid = float(b)
+        ask = float(a)
+    except (TypeError, ValueError):
+        return None
+    if bid <= 0 or ask <= 0:
+        return None
+    return (bid + ask) / 2.0
+
+
+class BinanceWsFeed:
+    """Binance bookTicker WS 스트림 → in-memory mid 캐시.
+
+    - subscribe(token_pair): 구독 심볼 등록 (start 이전에만 호출)
+    - start(): pair 별 영구 WS 태스크 생성
+    - latest(token_pair): 최신 mid (cache miss 또는 stale 이면 None)
+    - stop(): 태스크 cancel + await
+    """
+
+    def __init__(
+        self,
+        *,
+        stale_threshold_sec: float = 10.0,
+        backoff_initial: float = 0.5,
+        backoff_max: float = 10.0,
+        ping_interval: float = 20.0,
+        ping_timeout: float = 20.0,
+    ) -> None:
+        self._stale = stale_threshold_sec
+        self._backoff_initial = backoff_initial
+        self._backoff_max = backoff_max
+        self._ping_interval = ping_interval
+        self._ping_timeout = ping_timeout
+        self._subs: dict[str, str] = {}  # token_pair → 소문자 심볼 (URL 용)
+        self._cache: dict[str, tuple[float, float]] = {}  # token_pair → (mid, ts)
+        self._tasks: list[asyncio.Task] = []
+        self._stopping = False
+
+    def _now(self) -> float:
+        return time.monotonic()
+
+    def subscribe(self, token_pair: str) -> bool:
+        sym = binance_symbol(token_pair)
+        if sym is None:
+            logger.warning(
+                "BinanceWsFeed: 지원 안 되는 pair %s — REST fallback 만 사용",
+                token_pair,
+            )
+            return False
+        self._subs[token_pair] = sym.lower()
+        return True
+
+    def start(self) -> None:
+        if self._tasks:
+            return
+        self._stopping = False
+        for pair, sym in self._subs.items():
+            t = asyncio.create_task(self._run_stream(pair, sym))
+            self._tasks.append(t)
+        logger.info("BinanceWsFeed 시작: %d pair", len(self._tasks))
+
+    async def stop(self) -> None:
+        self._stopping = True
+        for t in self._tasks:
+            t.cancel()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
+        logger.info("BinanceWsFeed 정지")
+
+    def latest(self, token_pair: str) -> float | None:
+        entry = self._cache.get(token_pair)
+        if entry is None:
+            return None
+        mid, ts = entry
+        if (self._now() - ts) > self._stale:
+            return None
+        return mid
+
+    async def _run_stream(self, token_pair: str, symbol: str) -> None:
+        url = f"{BINANCE_WS_BASE}/{symbol}@bookTicker"
+        backoff = self._backoff_initial
+        while not self._stopping:
+            try:
+                async with websockets.connect(
+                    url,
+                    ping_interval=self._ping_interval,
+                    ping_timeout=self._ping_timeout,
+                ) as ws:
+                    logger.info("BinanceWsFeed 연결: %s", url)
+                    backoff = self._backoff_initial
+                    async for message in ws:
+                        mid = _parse_book_ticker(message)
+                        if mid is not None:
+                            self._cache[token_pair] = (mid, self._now())
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.warning(
+                    "BinanceWsFeed %s 연결 끊김, %.1fs 후 재시도: %s",
+                    symbol,
+                    backoff,
+                    e,
+                )
+                try:
+                    await asyncio.sleep(backoff)
+                except asyncio.CancelledError:
+                    break
+                backoff = min(backoff * 2.0, self._backoff_max)
 
 
 class PriceFeedListener:
@@ -32,16 +167,25 @@ class PriceFeedListener:
         binance_weight: float = 0.4,
         outlier_threshold_pct: float = 2.0,
         outlier_primary: str = "binance",
+        binance_ws: BinanceWsFeed | None = None,
     ) -> None:
         self._wp = pancake_weight
         self._wb = binance_weight
         self._threshold = outlier_threshold_pct
         self._primary = outlier_primary if outlier_primary in ("binance", "pancake") else "binance"
+        self._binance_ws = binance_ws
+
+    async def _fetch_binance(self, token_pair: str) -> float | None:
+        if self._binance_ws is not None:
+            cached = self._binance_ws.latest(token_pair)
+            if cached is not None:
+                return cached
+        return await fetch_binance_price(token_pair)
 
     async def get_mid_price(self, token_pair: str) -> MidPriceResult:
         pancake, binance = await asyncio.gather(
             fetch_pancakeswap_price(token_pair),
-            fetch_binance_price(token_pair),
+            self._fetch_binance(token_pair),
         )
 
         if pancake is None and binance is None:

--- a/apps/engine/src/pricing/binance.py
+++ b/apps/engine/src/pricing/binance.py
@@ -27,6 +27,14 @@ def _normalize_token_pair(token_pair: str) -> str | None:
     return None
 
 
+def binance_symbol(token_pair: str) -> str | None:
+    """token_pair 를 Binance REST/WS 심볼(대문자)로 변환. 지원 안 되면 None."""
+    norm = _normalize_token_pair(token_pair)
+    if norm is None:
+        return None
+    return _PAIR_SYMBOLS[norm]
+
+
 async def fetch_binance_price(token_pair: str) -> float | None:
     """Binance `GET /api/v3/ticker/price`로 심볼 현재가를 조회해 float로 반환한다."""
     norm = _normalize_token_pair(token_pair)

--- a/apps/engine/tests/test_mm_bot.py
+++ b/apps/engine/tests/test_mm_bot.py
@@ -50,6 +50,7 @@ def test_parse_book_ticker_rejects_malformed() -> None:
     assert _parse_book_ticker('{"b":"0","a":"0"}') is None  # 0 가격 거절
     assert _parse_book_ticker('{"b":"-1","a":"1"}') is None  # 음수 거절
     assert _parse_book_ticker("[1, 2, 3]") is None  # dict 아님
+    assert _parse_book_ticker('{"b":"101.0","a":"100.0"}') is None  # crossed (bid > ask)
 
 
 def test_binance_ws_cache_fresh_vs_stale() -> None:

--- a/apps/engine/tests/test_mm_bot.py
+++ b/apps/engine/tests/test_mm_bot.py
@@ -3,6 +3,7 @@
 from decimal import Decimal
 
 from src.mm_bot.order_gen import bid_ask_prices
+from src.mm_bot.price_feed import BinanceWsFeed, _parse_book_ticker
 from src.mm_bot.spread import SpreadCalculator, SpreadConfig
 
 
@@ -28,3 +29,59 @@ def test_spread_volatility_increases_bps() -> None:
     # 변동성 승수가 실제로 작동했는지 확인 — base_bps 보다 엄격히 커야 한다.
     assert eff > base_bps
     assert eff >= base_bps * 2.0
+
+
+def test_parse_book_ticker_valid() -> None:
+    raw = '{"u":400900217,"s":"BNBUSDT","b":"600.00","B":"1.5","a":"600.10","A":"1.2"}'
+    mid = _parse_book_ticker(raw)
+    assert mid is not None
+    assert abs(mid - 600.05) < 1e-9
+
+
+def test_parse_book_ticker_bytes_payload() -> None:
+    raw = b'{"b":"100.0","a":"102.0"}'
+    assert _parse_book_ticker(raw) == 101.0
+
+
+def test_parse_book_ticker_rejects_malformed() -> None:
+    assert _parse_book_ticker("not json") is None
+    assert _parse_book_ticker('{"u":1}') is None  # b, a 누락
+    assert _parse_book_ticker('{"b":"abc","a":"1"}') is None  # float 파싱 실패
+    assert _parse_book_ticker('{"b":"0","a":"0"}') is None  # 0 가격 거절
+    assert _parse_book_ticker('{"b":"-1","a":"1"}') is None  # 음수 거절
+    assert _parse_book_ticker("[1, 2, 3]") is None  # dict 아님
+
+
+def test_binance_ws_cache_fresh_vs_stale() -> None:
+    feed = BinanceWsFeed(stale_threshold_sec=5.0)
+
+    # 테스트 전용 시계 주입
+    now = [100.0]
+    feed._now = lambda: now[0]  # type: ignore[method-assign]
+
+    # cache miss
+    assert feed.latest("BNB/USDT") is None
+
+    # cache put
+    feed._cache["BNB/USDT"] = (600.0, 100.0)
+    assert feed.latest("BNB/USDT") == 600.0
+
+    # 4.9s 경과 → 여전히 fresh
+    now[0] = 104.9
+    assert feed.latest("BNB/USDT") == 600.0
+
+    # 5.1s 경과 → stale
+    now[0] = 105.1
+    assert feed.latest("BNB/USDT") is None
+
+
+def test_binance_ws_subscribe_unknown_pair_rejected() -> None:
+    feed = BinanceWsFeed()
+    assert feed.subscribe("UNKNOWN/PAIR") is False
+    assert "UNKNOWN/PAIR" not in feed._subs
+
+
+def test_binance_ws_subscribe_known_pair() -> None:
+    feed = BinanceWsFeed()
+    assert feed.subscribe("BNB/USDT") is True
+    assert feed._subs["BNB/USDT"] == "bnbusdt"

--- a/apps/engine/uv.lock
+++ b/apps/engine/uv.lock
@@ -308,6 +308,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "web3" },
+    { name = "websockets" },
 ]
 
 [package.dev-dependencies]
@@ -326,6 +327,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0,<7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34,<1.0" },
     { name = "web3", specifier = ">=7.0,<8.0" },
+    { name = "websockets", specifier = ">=13,<16" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## 요약

Closes #18

MM 봇(#17) 의 Binance 가격 피드를 REST polling 에서 \`bookTicker\` WebSocket 스트림으로 업그레이드. tick 5s 지연 → <100ms, 매 tick TLS 재협상 제거. Pancake 경로는 그대로 (배경: #17 의 설계 판단 코멘트).

## 변경 사항

### \`src/mm_bot/price_feed.py\` (+150)
- \`_parse_book_ticker(raw)\` 순수 함수 — JSON → (bid+ask)/2
- \`BinanceWsFeed\` 클래스 — subscribe/start/latest/stop API, pair 별 영구 태스크, exponential backoff 재연결 (0.5s → 10s), ping/pong 20s, 캐시 staleness 10s
- \`PriceFeedListener\` 에 \`binance_ws\` DI + 내부 \`_fetch_binance\` 헬퍼 (cache hit → miss 시 REST fallback)
- 기존 gather / outlier / 단일 소스 로직 0 수정

### \`src/mm_bot/bot.py\`
- \`MMBot.__init__\` 에서 \`BinanceWsFeed\` 생성 + \`PriceFeedListener\` 에 주입
- \`run_forever\` 진입 시 pair 구독 + start, \`try/finally\` 로 stop() 보장
- \`mm_config.yaml enabled=false\` 면 WS 연결 자체 없음 → 엔진 회귀 0

### \`src/pricing/binance.py\`
- \`binance_symbol(token_pair)\` public helper 추출 → REST 경로와 WS 경로가 같은 심볼 매핑 공유

### \`pyproject.toml\` + \`uv.lock\`
- \`websockets>=13,<16\` direct dependency 선언 (기존 transitive 를 명시적으로 승격)

### \`tests/test_mm_bot.py\` (+6)
- parser 3 케이스 (정상 / bytes / 6종 rejection)
- cache staleness monkeypatch
- subscribe 지원/미지원 pair

## 기술적 판단

### 라이브러리 선택
\`aiohttp\` 는 WS 내장이지만 엔진이 이미 httpx 로 통일 → dual HTTP stack 회피. \`websockets\` 라이브러리 (검증된 표준, benchmark 92.8) 를 별도 의존으로 추가. \`httpx-ws\` 는 도입 사례 얕아 제외. (#17 판단 근거 유지)

### WS 라이프사이클을 MM 봇 내부에 둔 이유
WS feed 를 lifespan 에 올려 독립 태스크로 만들 수도 있었지만, 현재 유일한 소비자가 MM 봇 하나이고 \`enabled=false\` 상태에서 WS 연결이 떠있을 이유가 없어서 **MM 봇 인스턴스가 소유**하는 구조를 선택. 엔진 본체 lifespan 코드 변경 없음.

### Fallback 정책
WS cache hit 시 즉시 반환, miss/stale 시 기존 \`fetch_binance_price\` REST 경로로 자연스럽게 빠짐. 즉 **신뢰할 수 있는 fallback 이 항상 살아있음** → WS 가 잠시 끊겨도 MM 봇은 계속 동작.

### 테스트 전략
\`_parse_book_ticker\` / staleness / subscribe 를 순수 함수·독립 단위로 분리해 WS 없이 테스트 가능. 실 WS 연결·재연결 테스트는 mock server 비용 대비 가치가 낮아 스킵, 통합 테스트 / 수동 smoke test 로 위임.

## 검증

- \`uv run ruff check\` → \`All checks passed!\`
- \`uv run pytest -q\` → \`124 passed, 164 warnings in 0.93s\` (기존 118 + 새 6, regression 0)
- 수동 smoke test 는 머지 후 \`.env\` + \`mm_config.yaml enabled=true\` 로 별도 진행 필요

## 후속 작업

- #17 의 수동 smoke test 체크박스와 본 이슈 smoke test 를 같은 세팅에서 동시 검증 가능
- pair 가 2개 이상 되면 \`/stream?streams=...\` multiplex 도입 고려
- Pancake WS (BSC WSS + Swap 이벤트) 는 여전히 별도 스코프

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated a Binance WebSocket feed for real-time pricing with in-memory caching, staleness detection, and REST fallback when WS data is unavailable.
  * Added symbol normalization to improve Binance pair support.

* **Bug Fixes / Reliability**
  * Improved feed startup/shutdown to ensure clean termination and reduce missed/duplicated ticks.

* **Tests**
  * Added unit tests for WS message parsing, cache staleness, and pair subscription behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->