### PR TITLE
feat(engine): /attestation/verify FastAPI 라우트 추가

### DIFF
--- a/apps/engine/src/attestation/verifier.py
+++ b/apps/engine/src/attestation/verifier.py
@@ -18,7 +18,36 @@ class AttestationResult:
     signing_addresses: list[str] = field(default_factory=list)
     gpu_verified: bool = False
     gpu_results: list[dict] = field(default_factory=list)
+    enclave_measurement: str = ""
+    gpu_model: str = ""
     error: str | None = None
+
+
+def extract_enclave_measurement(report: dict) -> str:
+    """report에서 enclave_measurement를 best-effort 추출한다."""
+    em = report.get("enclave_measurement")
+    if em:
+        return str(em)
+    for att in report.get("model_attestations", []):
+        em = att.get("enclave_measurement")
+        if em:
+            return str(em)
+    return ""
+
+
+def extract_gpu_model_from_jwt(gpu_resp: dict | list) -> str:
+    """NVIDIA GPU attestation 응답의 JWT에서 GPU 모델명을 추출한다."""
+    token = _extract_jwt_token(gpu_resp)
+    if not token:
+        return ""
+    payload = decode_nvidia_jwt_payload(token)
+    if not payload:
+        return ""
+    return str(
+        payload.get("x-nvidia-hwmodel")
+        or payload.get("x-nvidia-gpu-arch")
+        or ""
+    )
 
 
 def extract_signing_addresses(report: dict) -> list[str]:
@@ -86,9 +115,12 @@ async def verify_attestation(model: str) -> AttestationResult:
 
     logger.info("TEE signing addresses: %s", addresses)
 
+    enclave_measurement = extract_enclave_measurement(report)
+
     nvidia_payloads = extract_nvidia_payloads(report)
     gpu_results: list[dict] = []
     all_passed = True
+    gpu_model = ""
 
     for i, payload in enumerate(nvidia_payloads):
         gpu_resp = await verify_gpu_attestation(payload)
@@ -96,6 +128,9 @@ async def verify_attestation(model: str) -> AttestationResult:
             gpu_results.append({"index": i, "passed": False, "error": "검증 요청 실패"})
             all_passed = False
             continue
+
+        if not gpu_model:
+            gpu_model = extract_gpu_model_from_jwt(gpu_resp)
 
         eat_token = _extract_jwt_token(gpu_resp)
 
@@ -121,4 +156,6 @@ async def verify_attestation(model: str) -> AttestationResult:
         signing_addresses=addresses,
         gpu_verified=gpu_verified,
         gpu_results=gpu_results,
+        enclave_measurement=enclave_measurement,
+        gpu_model=gpu_model,
     )

--- a/apps/engine/src/attestation/verifier.py
+++ b/apps/engine/src/attestation/verifier.py
@@ -28,7 +28,9 @@ def extract_enclave_measurement(report: dict) -> str:
     em = report.get("enclave_measurement")
     if em:
         return str(em)
-    for att in report.get("model_attestations", []):
+    for att in report.get("model_attestations") or []:
+        if not isinstance(att, dict):
+            continue
         em = att.get("enclave_measurement")
         if em:
             return str(em)

--- a/apps/engine/src/config.py
+++ b/apps/engine/src/config.py
@@ -16,6 +16,8 @@ NVIDIA_ATTESTATION_URL = os.getenv(
     "NVIDIA_ATTESTATION_URL", "https://nras.attestation.nvidia.com/v3/attest/gpu"
 )
 
+NEAR_AI_MODEL = os.getenv("NEAR_AI_MODEL", "deepseek-ai/DeepSeek-V3.1")
+
 # --- Pricing / Slippage ---
 SLIPPAGE_LIMIT_PCT = float(os.getenv("SLIPPAGE_LIMIT_PCT", "1.5"))
 MIN_FILL_AMOUNT = float(os.getenv("MIN_FILL_AMOUNT", "0"))

--- a/apps/engine/src/routes.py
+++ b/apps/engine/src/routes.py
@@ -3,12 +3,15 @@
 import asyncio
 import logging
 import uuid
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, HTTPException, Request, WebSocket, WebSocketDisconnect
 
+from src.attestation.verifier import verify_attestation
+from src.config import NEAR_AI_MODEL, NEARAI_CLOUD_API_KEY
 from src.matching.runner import run_matching_cycle
 from src.models import Order, OrderBook
-from src.schemas import OrderCreateRequest, OrderResponse
+from src.schemas import AttestationResponse, OrderCreateRequest, OrderResponse
 from src.ws import ConnectionManager
 
 logger = logging.getLogger(__name__)
@@ -95,6 +98,35 @@ async def cancel_order(order_id: str, request: Request) -> OrderResponse:
     except Exception:
         logger.exception("broadcast 실패 (cancelled, order_id=%s)", order_id)
     return response
+
+
+@router.get("/attestation/verify", response_model=AttestationResponse)
+async def verify_attestation_endpoint() -> AttestationResponse:
+    """TEE attestation 검증 결과를 반환한다."""
+    if not NEARAI_CLOUD_API_KEY:
+        raise HTTPException(
+            status_code=503,
+            detail="attestation backend not configured",
+        )
+
+    try:
+        result = await verify_attestation(NEAR_AI_MODEL)
+    except Exception as exc:
+        logger.exception("attestation 검증 중 예외 발생")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    if not result.success:
+        raise HTTPException(status_code=503, detail=result.error or "attestation 검증 실패")
+
+    return AttestationResponse(
+        success=result.success,
+        enclave_measurement=result.enclave_measurement,
+        signing_addresses=result.signing_addresses,
+        gpu_verified=result.gpu_verified,
+        gpu_model=result.gpu_model,
+        code_integrity="matching_engine v0.1.0",
+        timestamp=datetime.now(UTC).isoformat(),
+    )
 
 
 @router.websocket("/ws")

--- a/apps/engine/src/routes.py
+++ b/apps/engine/src/routes.py
@@ -113,7 +113,7 @@ async def verify_attestation_endpoint() -> AttestationResponse:
         result = await verify_attestation(NEAR_AI_MODEL)
     except Exception as exc:
         logger.exception("attestation 검증 중 예외 발생")
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise HTTPException(status_code=500, detail="Internal server error") from exc
 
     if not result.success:
         raise HTTPException(status_code=503, detail=result.error or "attestation 검증 실패")

--- a/apps/engine/src/schemas.py
+++ b/apps/engine/src/schemas.py
@@ -3,7 +3,7 @@
 from decimal import Decimal
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class OrderCreateRequest(BaseModel):
@@ -25,6 +25,20 @@ class OrderResponse(BaseModel):
     wallet_address: str
     status: str
     created_at: str
+
+
+class AttestationResponse(BaseModel):
+    """TEE attestation 검증 응답 — frontend AttestationResult 매핑."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    success: bool
+    enclave_measurement: str
+    signing_addresses: list[str]
+    gpu_verified: bool
+    gpu_model: str
+    code_integrity: str
+    timestamp: str
 
 
 class ErrorResponse(BaseModel):

--- a/apps/engine/tests/test_api.py
+++ b/apps/engine/tests/test_api.py
@@ -196,4 +196,4 @@ class TestAttestationVerify:
             resp = client.get("/attestation/verify")
 
         assert resp.status_code == 500
-        assert "connection refused" in resp.json()["detail"]
+        assert resp.json()["detail"] == "Internal server error"

--- a/apps/engine/tests/test_api.py
+++ b/apps/engine/tests/test_api.py
@@ -1,8 +1,12 @@
 """주문 API 엔드포인트 테스트."""
 
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from fastapi.testclient import TestClient
 
+from src.attestation.verifier import AttestationResult
 from src.main import app
 
 
@@ -129,3 +133,67 @@ class TestHealth:
         response = client.get("/health")
         assert response.status_code == 200
         assert response.json() == {"status": "ok"}
+
+
+class TestAttestationVerify:
+    def test_success(self, client, monkeypatch):
+        monkeypatch.setattr("src.routes.NEARAI_CLOUD_API_KEY", "test-key")
+        mock_result = AttestationResult(
+            success=True,
+            signing_addresses=["0xABC"],
+            gpu_verified=True,
+            gpu_results=[{"index": 0, "passed": True}],
+            enclave_measurement="enclave_abc",
+            gpu_model="NVIDIA H100",
+        )
+        with patch(
+            "src.routes.verify_attestation",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            resp = client.get("/attestation/verify")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["enclave_measurement"] == "enclave_abc"
+        assert data["signing_addresses"] == ["0xABC"]
+        assert data["gpu_verified"] is True
+        assert data["gpu_model"] == "NVIDIA H100"
+        assert data["code_integrity"] == "matching_engine v0.1.0"
+        # timestamp는 ISO 8601 파싱 가능한지 확인
+        datetime.fromisoformat(data["timestamp"])
+
+    def test_api_key_not_configured(self, client, monkeypatch):
+        monkeypatch.setattr("src.routes.NEARAI_CLOUD_API_KEY", "")
+        resp = client.get("/attestation/verify")
+        assert resp.status_code == 503
+        assert "not configured" in resp.json()["detail"]
+
+    def test_verification_failure(self, client, monkeypatch):
+        monkeypatch.setattr("src.routes.NEARAI_CLOUD_API_KEY", "test-key")
+        mock_result = AttestationResult(
+            success=False,
+            error="attestation report 조회 실패",
+        )
+        with patch(
+            "src.routes.verify_attestation",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            resp = client.get("/attestation/verify")
+
+        assert resp.status_code == 503
+        assert "조회 실패" in resp.json()["detail"]
+
+    def test_unexpected_exception(self, client, monkeypatch):
+        monkeypatch.setattr("src.routes.NEARAI_CLOUD_API_KEY", "test-key")
+        with patch(
+            "src.routes.verify_attestation",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("connection refused"),
+        ):
+            resp = client.get("/attestation/verify")
+
+        assert resp.status_code == 500
+        assert "connection refused" in resp.json()["detail"]

--- a/apps/engine/tests/test_attestation.py
+++ b/apps/engine/tests/test_attestation.py
@@ -8,6 +8,8 @@ import pytest
 
 from src.attestation.verifier import (
     decode_nvidia_jwt_payload,
+    extract_enclave_measurement,
+    extract_gpu_model_from_jwt,
     extract_nvidia_payloads,
     extract_signing_addresses,
     verify_attestation,
@@ -183,3 +185,83 @@ class TestVerifyAttestation:
 
         assert result.success is True
         assert result.gpu_verified is False
+
+
+class TestExtractEnclaveMeasurement:
+    def test_top_level(self):
+        report = {"enclave_measurement": "abc123"}
+        assert extract_enclave_measurement(report) == "abc123"
+
+    def test_from_model_attestation(self):
+        report = {"model_attestations": [{"enclave_measurement": "def456"}]}
+        assert extract_enclave_measurement(report) == "def456"
+
+    def test_top_level_takes_priority(self):
+        report = {
+            "enclave_measurement": "top",
+            "model_attestations": [{"enclave_measurement": "nested"}],
+        }
+        assert extract_enclave_measurement(report) == "top"
+
+    def test_empty_report(self):
+        assert extract_enclave_measurement({}) == ""
+
+    def test_no_measurement(self):
+        assert extract_enclave_measurement(SAMPLE_REPORT) == ""
+
+
+class TestExtractGpuModel:
+    def test_hwmodel(self):
+        jwt = _make_jwt({"x-nvidia-hwmodel": "NVIDIA H100"})
+        resp = {"eat_token": jwt}
+        assert extract_gpu_model_from_jwt(resp) == "NVIDIA H100"
+
+    def test_gpu_arch_fallback(self):
+        jwt = _make_jwt({"x-nvidia-gpu-arch": "Hopper"})
+        resp = {"eat_token": jwt}
+        assert extract_gpu_model_from_jwt(resp) == "Hopper"
+
+    def test_no_gpu_info(self):
+        jwt = _make_jwt({"x-nvidia-overall-att-result": True})
+        resp = {"eat_token": jwt}
+        assert extract_gpu_model_from_jwt(resp) == ""
+
+    def test_no_jwt(self):
+        assert extract_gpu_model_from_jwt({}) == ""
+
+
+class TestVerifyAttestationNewFields:
+    @pytest.mark.asyncio
+    async def test_enclave_and_gpu_model_populated(self):
+        report_with_enclave = {
+            "enclave_measurement": "enclave_abc",
+            "model_attestations": [
+                {
+                    "signing_address": "0xABCD",
+                    "nvidia_payload": '{"evidence": "test"}',
+                },
+            ],
+        }
+        jwt = _make_jwt({
+            "x-nvidia-overall-att-result": True,
+            "x-nvidia-hwmodel": "NVIDIA A100",
+        })
+        nvidia_resp = {"eat_token": jwt}
+
+        with (
+            patch(
+                "src.attestation.verifier.fetch_attestation_report",
+                new_callable=AsyncMock,
+                return_value=report_with_enclave,
+            ),
+            patch(
+                "src.attestation.verifier.verify_gpu_attestation",
+                new_callable=AsyncMock,
+                return_value=nvidia_resp,
+            ),
+        ):
+            result = await verify_attestation("test-model")
+
+        assert result.success is True
+        assert result.enclave_measurement == "enclave_abc"
+        assert result.gpu_model == "NVIDIA A100"

--- a/apps/engine/tests/test_attestation.py
+++ b/apps/engine/tests/test_attestation.py
@@ -209,6 +209,18 @@ class TestExtractEnclaveMeasurement:
     def test_no_measurement(self):
         assert extract_enclave_measurement(SAMPLE_REPORT) == ""
 
+    def test_model_attestations_not_a_list(self):
+        assert extract_enclave_measurement({"model_attestations": None}) == ""
+        assert extract_enclave_measurement({"model_attestations": "bad"}) == ""
+
+    def test_model_attestations_contains_non_dict(self):
+        report = {"model_attestations": [None, "x", 42, {"enclave_measurement": "valid"}]}
+        assert extract_enclave_measurement(report) == "valid"
+
+    def test_model_attestations_all_non_dict(self):
+        report = {"model_attestations": [None, "x", 42]}
+        assert extract_enclave_measurement(report) == ""
+
 
 class TestExtractGpuModel:
     def test_hwmodel(self):
@@ -228,6 +240,14 @@ class TestExtractGpuModel:
 
     def test_no_jwt(self):
         assert extract_gpu_model_from_jwt({}) == ""
+
+    def test_eat_token_not_a_string(self):
+        assert extract_gpu_model_from_jwt({"eat_token": 12345}) == ""
+        assert extract_gpu_model_from_jwt({"eat_token": None}) == ""
+
+    def test_eat_token_malformed_jwt(self):
+        assert extract_gpu_model_from_jwt({"eat_token": "not-a-jwt"}) == ""
+        assert extract_gpu_model_from_jwt({"eat_token": "a.b.c.d.e"}) == ""
 
 
 class TestVerifyAttestationNewFields:


### PR DESCRIPTION
## 요약

Closes #22

engine에 `GET /attestation/verify` 엔드포인트를 추가하여 frontend가 TEE attestation 결과를 사전 검증할 수 있도록 한다.

## 변경 사항

- `src/attestation/verifier.py`: `AttestationResult` dataclass에 `enclave_measurement`, `gpu_model` 필드 추가 + best-effort 추출 헬퍼 2개
- `src/config.py`: `NEAR_AI_MODEL` 환경변수 추가
- `src/schemas.py`: `AttestationResponse` Pydantic 모델 (frontend `AttestationResult` 전체 매핑, `extra="forbid"`)
- `src/routes.py`: `GET /attestation/verify` 핸들러 (503/500/200 분기)
- `tests/test_attestation.py`: 새 추출 함수 + 통합 테스트 10건 추가
- `tests/test_api.py`: API 엔드포인트 테스트 4건 추가

## 기술적 판단

- **스키마 매핑**: frontend `AttestationResult`와 engine dataclass 간 1:1 매핑 안 되는 필드(`enclave_measurement`, `gpu_model`, `code_integrity`, `timestamp`)는 Issue #22 코멘트에 기록한 방식대로 best-effort 추출 / 하드코드 / 서버 시각으로 처리
- **에러 처리**: API 키 미설정은 설정 오류이므로 503 (검증 스킵 아님), verifier 실패도 503, 예외는 500
- **하위 호환**: 기존 `AttestationResult` 필드는 모두 default 값이라 기존 테스트 영향 없음
- **CORS**: 본 PR 스코프 외 — smoke test 시 필요하면 별도 이슈로 분리

## 검증

- pytest: **138 passed** (기존 124 + 신규 14)
- ruff: clean
- 수동 검증: frontend #21 머지 후 smoke test 필요 (engine `/attestation/verify` 없는 상태에서 frontend는 graceful degrade)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GET /attestation/verify endpoint that returns attestation results including enclave measurement, signing addresses, GPU verification and model, code integrity, and timestamp.
  * Added NEAR_AI_MODEL configuration (env var, default provided).

* **Tests**
  * Added tests covering the attestation endpoint and helper behavior for extracting enclave measurement and GPU model, including success and error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->