### PR TITLE
fix(frontend): TEE Attestation UI를 실제 검증 결과에 연동

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1218,7 +1218,11 @@ export default function App() {
                         <span className="text-emerald-500">{'>'}</span>
                         <span className="text-neutral-300">Enclave measurement</span>
                         <span className="text-neutral-600">NEAR AI Cloud</span>
-                        {matchStep >= 2 ? <span className="text-emerald-500 ml-auto">VALID</span> : <Loader2 className="w-3 h-3 text-emerald-400 animate-spin ml-auto" />}
+                        {matchStep >= 2
+                          ? attestation?.success
+                            ? <span className="text-emerald-500 ml-auto">VALID</span>
+                            : <span className="text-amber-500 ml-auto">UNVERIFIED</span>
+                          : <Loader2 className="w-3 h-3 text-emerald-400 animate-spin ml-auto" />}
                       </div>
                     )}
                     {matchStep >= 1 && matchStep < 2 && (
@@ -1230,10 +1234,12 @@ export default function App() {
                     )}
                     {matchStep >= 2 && (
                       <div className="flex items-center gap-2">
-                        <span className="text-emerald-500">{'>'}</span>
+                        <span className={attestation?.success ? 'text-emerald-500' : 'text-amber-500'}>{'>'}</span>
                         <span className="text-neutral-300">GPU attestation</span>
-                        <span className="text-neutral-500">{attestation?.gpu_model || 'NVIDIA H100'}</span>
-                        <span className="text-emerald-500 ml-auto">VERIFIED</span>
+                        <span className="text-neutral-500">{attestation?.gpu_model || '—'}</span>
+                        {attestation?.success
+                          ? <span className="text-emerald-500 ml-auto">VERIFIED</span>
+                          : <span className="text-amber-500 ml-auto">UNVERIFIED</span>}
                       </div>
                     )}
                     {matchStep >= 2 && attestation && (
@@ -1327,7 +1333,9 @@ export default function App() {
                 <div className="mt-3 flex items-center justify-between text-xs font-mono text-neutral-500">
                   <div className="flex items-center gap-1.5">
                     <ShieldCheck className="w-3.5 h-3.5" />
-                    <span>{matchStep >= 2 ? 'TEE Verified' : matchStep >= 1 ? 'Verifying TEE...' : 'Attestation pending'}</span>
+                    <span>{matchStep >= 2
+                      ? attestation?.success ? 'TEE Verified' : 'TEE Unverified'
+                      : matchStep >= 1 ? 'Verifying TEE...' : 'Attestation pending'}</span>
                   </div>
                   <div className="flex items-center gap-1.5">
                     <div className={`w-1.5 h-1.5 rounded-full ${matchStep > 0 ? 'bg-emerald-500 animate-pulse' : 'bg-neutral-600'}`} />
@@ -1483,16 +1491,16 @@ export default function App() {
                 <div className="bg-neutral-900/50 border border-neutral-800 rounded-lg p-4 mb-4">
                   <div className="flex items-center justify-between">
                     <span className="text-[10px] font-mono text-neutral-600 uppercase tracking-wider">TEE Attestation</span>
-                    <span className="text-[9px] font-mono text-emerald-500/60">pre-verified</span>
+                    <span className={`text-[9px] font-mono ${attestation?.success ? 'text-emerald-500/60' : 'text-amber-500/60'}`}>{attestation?.success ? 'pre-verified' : 'unverified'}</span>
                   </div>
                   <div className="mt-3 space-y-2">
                     <div className="flex items-center justify-between text-xs">
                       <span className="text-neutral-500">Enclave measurement</span>
-                      <span className="font-mono text-emerald-500/70 text-[10px]">{attestation?.enclave_measurement || 'n/a'}</span>
+                      <span className={`font-mono text-[10px] ${attestation?.success ? 'text-emerald-500/70' : 'text-neutral-600'}`}>{attestation?.enclave_measurement || 'n/a'}</span>
                     </div>
                     <div className="flex items-center justify-between text-xs">
                       <span className="text-neutral-500">GPU attestation</span>
-                      <span className="font-mono text-emerald-500/70 text-[10px]">{attestation ? `${attestation.gpu_model} verified` : 'n/a'}</span>
+                      <span className={`font-mono text-[10px] ${attestation?.success ? 'text-emerald-500/70' : 'text-neutral-600'}`}>{attestation?.success ? `${attestation.gpu_model} verified` : 'n/a'}</span>
                     </div>
                     <div className="flex items-center justify-between text-xs">
                       <span className="text-neutral-500">Code integrity</span>

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1504,17 +1504,19 @@ export default function App() {
                     </div>
                     <div className="flex items-center justify-between text-xs">
                       <span className="text-neutral-500">Code integrity</span>
-                      <span className="font-mono text-emerald-500/70 text-[10px]">{attestation?.code_integrity || 'n/a'}</span>
+                      <span className={`font-mono text-[10px] ${attestation?.success ? 'text-emerald-500/70' : 'text-neutral-600'}`}>{attestation?.code_integrity || 'n/a'}</span>
                     </div>
                     {attestation?.signing_addresses?.[0] && (
                       <div className="flex items-center justify-between text-xs">
                         <span className="text-neutral-500">Signing address</span>
-                        <span className="font-mono text-emerald-500/70 text-[10px]">{attestation.signing_addresses[0].substring(0, 8)}...{attestation.signing_addresses[0].substring(36)}</span>
+                        <span className={`font-mono text-[10px] ${attestation?.success ? 'text-emerald-500/70' : 'text-neutral-600'}`}>{attestation.signing_addresses[0].substring(0, 8)}...{attestation.signing_addresses[0].substring(36)}</span>
                       </div>
                     )}
                   </div>
                   <div className="mt-2 pt-2 border-t border-neutral-800 text-[10px] font-mono text-neutral-600">
-                    TEE environment verified before order entered enclave
+                    {attestation?.success
+                      ? 'TEE environment verified before order entered enclave'
+                      : 'TEE attestation unavailable — verification skipped'}
                   </div>
                 </div>
 


### PR DESCRIPTION
## 요약

Closes #24

TEE Attestation UI가 `matchStep`만으로 "VERIFIED"/"VALID"를 표시하던 문제를 수정. `attestation?.success` 기반으로 실제 검증 상태를 반영하도록 변경.

## 변경 사항

- `src/App.tsx`: Phase 3 Terminal log + Footer + Phase 5 결과 카드의 attestation 라벨을 3분기 표시
  - 성공: 초록 VALID/VERIFIED (기존과 동일)
  - 미검증/실패: amber UNVERIFIED
  - GPU model fallback `'NVIDIA H100'` 하드코딩 제거 → `'—'`

## 기술적 판단

- **Option B (degraded display) 채택**: attestation 실패해도 매칭은 계속 진행, 라벨만 정직하게 표시. 데모 가능 + 보안 주장 정직함 사이 타협.
- **matchStep 진행 로직 미변경**: 매칭 플로우 애니메이션은 기존 그대로 유지. attestation-specific 요소(VALID/VERIFIED/GPU model/enclave measurement)만 실 데이터 기반으로 전환.
- **Option A (strict) 미채택 이유**: engine 엔드포인트 없이 데모 불가. Option C (simulation badge)는 프로덕션에서 별도 UI 필요해 결국 B와 병행해야 함.

## 검증

- `npm run lint` (tsc --noEmit): 통과
- 수동 검증: engine `/attestation/verify` 있는 상태 / 없는 상태 둘 다에서 UI 일관성 확인 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TEE attestation status display now reflects actual attestation results rather than step progression.
  * Enclave measurement row shows VALID only when attestation succeeds; otherwise UNVERIFIED (spinners preserved before verification).
  * GPU attestation row and footer toggle between VERIFIED/UNVERIFIED and show a fallback model when unavailable.
  * Attestation card badges and emphasis styling update based on attestation outcome.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->