### PR TITLE
feat: AI 매칭 reasoning WebSocket/UI 표시

### DIFF
--- a/apps/engine/src/matching/engine.py
+++ b/apps/engine/src/matching/engine.py
@@ -44,6 +44,8 @@ class MatchingEngine:
 
     def __init__(self, orderbook: OrderBook) -> None:
         self._book = orderbook
+        self.last_engine_used: str = "rules"
+        self.last_reasoning: str = ""
 
     async def run_matching_cycle(self, token_pair: str) -> list[MatchResult]:
         """매칭 사이클을 실행한다.
@@ -84,6 +86,8 @@ class MatchingEngine:
         else:
             rules = RulesEngine(self._book, slippage_pct=slippage_pct)
             results = rules.try_match(token_pair, fair_decimal)
+            self.last_engine_used = "rules"
+            self.last_reasoning = rules.last_reasoning
 
         # 4. 상태 업데이트
         matching_state.update_fair_price(fair_price)
@@ -116,17 +120,20 @@ class MatchingEngine:
                 logger.exception("call_matching failed")
                 return {"error": "exception"}
 
+        rules_engine = RulesEngine(rules_book, slippage_pct=slippage_pct)
+
         async def _rules_coro() -> list[MatchResult]:
-            rules = RulesEngine(rules_book, slippage_pct=slippage_pct)
-            return rules.try_match(token_pair, fair_decimal)
+            return rules_engine.try_match(token_pair, fair_decimal)
 
         rules_results, raw_llm = await asyncio.gather(_rules_coro(), _llm_coro())
 
         rules_fill = sum(r.maker_fill_amount for r in rules_results)
         chosen = rules_results
         use_llm = False
+        llm_reasoning = ""
 
         if isinstance(raw_llm, dict) and not raw_llm.get("error"):
+            llm_reasoning = raw_llm.get("reasoning", "")
             validated = validate_matching_result(
                 raw_llm, orders_snapshot, fair_price, matching_state.prev_fair_price
             )
@@ -140,6 +147,9 @@ class MatchingEngine:
         for m in chosen:
             self._book.fill(m.maker_order_id, m.maker_fill_amount)
             self._book.fill(m.taker_order_id, m.maker_fill_amount)
+
+        self.last_engine_used = "llm" if use_llm else "rules"
+        self.last_reasoning = llm_reasoning if use_llm else rules_engine.last_reasoning
 
         logger.info(
             "dual-pass 완료: %s, %d건 체결",

--- a/apps/engine/src/matching/prompt.py
+++ b/apps/engine/src/matching/prompt.py
@@ -43,6 +43,11 @@ SYSTEM_PROMPT = """\
 - remaining_orders에는 아직 잔량이 남은 주문만 넣는다.
 - 응답 최상위 키: "matches", "remaining_orders", "fair_price" (이번 라운드에 사용한 공정가, 숫자).
 
+## 7. 매칭 근거 (reasoning)
+응답 JSON에 "reasoning" 키로 매칭 판단 근거를 **영문 한 문단**으로 작성한다.
+포함할 내용: 분석한 주문 수, 선택한 매칭 전략, 체결가 산출 근거, 매수·매도 양측의 price improvement(시장가 대비 개선율 %).
+매칭이 없으면 매칭 불가 사유를 적는다.
+
 위 규칙과 입력 주문·공정가에 맞게 매칭 결과만 JSON으로 반환한다.\
 """
 

--- a/apps/engine/src/matching/rules_engine.py
+++ b/apps/engine/src/matching/rules_engine.py
@@ -30,6 +30,7 @@ class RulesEngine:
         self._book = orderbook
         self._slippage_pct = Decimal(str(slippage_pct))
         self._min_fill = Decimal(str(min_fill))
+        self.last_reasoning: str = ""
 
     def try_match(self, token_pair: str, fair_price: Decimal) -> list[MatchResult]:
         """대기 중인 주문들을 매칭 규칙에 따라 체결."""
@@ -41,6 +42,7 @@ class RulesEngine:
         sells = self._sorted_sells(token_pair)
 
         results: list[MatchResult] = []
+        reasoning_parts: list[str] = []
         buy_idx = 0
         sell_idx = 0
 
@@ -89,6 +91,21 @@ class RulesEngine:
             )
             results.append(result)
 
+            buy_improvement = (
+                (buy.limit_price - fair_price) / buy.limit_price * 100
+                if buy.limit_price > 0 else Decimal("0")
+            )
+            sell_improvement = (
+                (fair_price - sell.limit_price) / sell.limit_price * 100
+                if sell.limit_price > 0 else Decimal("0")
+            )
+            reasoning_parts.append(
+                f"Matched buy@{buy.limit_price} with sell@{sell.limit_price}, "
+                f"execution at fair price {fair_price}, fill {fill_qty} units. "
+                f"Buyer saves {buy_improvement:.2f}% vs limit, "
+                f"seller gains {sell_improvement:.2f}% vs limit."
+            )
+
             logger.info(
                 "매칭 체결: %s ← %s, qty=%s, price=%s",
                 buy.order_id[:8],
@@ -101,6 +118,26 @@ class RulesEngine:
                 buy_idx += 1
             if not sell.is_active:
                 sell_idx += 1
+
+        if results:
+            n_buys = len(buys)
+            n_sells = len(sells)
+            total_fill = sum(r.maker_fill_amount for r in results)
+            summary = (
+                f"Analyzed {n_buys} buy and {n_sells} sell orders "
+                f"using price-time priority matching. "
+                f"Executed {len(results)} match(es), "
+                f"total fill volume {total_fill} units "
+                f"at fair price {fair_price}."
+            )
+            self.last_reasoning = (
+                summary + " " + " ".join(reasoning_parts)
+            )
+        else:
+            self.last_reasoning = (
+                f"Analyzed {len(buys)} buy and {len(sells)} sell orders. "
+                "No compatible price overlap found — no matches executed."
+            )
 
         return results
 

--- a/apps/engine/src/matching/runner.py
+++ b/apps/engine/src/matching/runner.py
@@ -36,7 +36,12 @@ async def run_matching_cycle(
             except Exception:
                 logger.exception("MM 봇 on_match_outcomes 실패")
 
-        await ws_manager.broadcast({"action": "matched", "results": outcomes})
+        await ws_manager.broadcast({
+            "action": "matched",
+            "results": outcomes,
+            "engine_used": engine.last_engine_used,
+            "reasoning": engine.last_reasoning,
+        })
 
         submitted = [o for o in outcomes if o.get("tx_hash")]
         if submitted:

--- a/apps/engine/src/matching/schema.py
+++ b/apps/engine/src/matching/schema.py
@@ -59,8 +59,9 @@ MATCHING_LLM_JSON_SCHEMA: Final[dict[str, Any]] = {
         "matches": {"type": "array", "items": _MATCH_RESULT_ITEM_SCHEMA},
         "remaining_orders": {"type": "array", "items": _REMAINING_ORDER_ITEM_SCHEMA},
         "fair_price": {"type": "number"},
+        "reasoning": {"type": "string"},
     },
-    "required": ["matches", "remaining_orders", "fair_price"],
+    "required": ["matches", "remaining_orders", "fair_price", "reasoning"],
     "additionalProperties": False,
 }
 

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -465,6 +465,7 @@ export default function App() {
     setMatchStep(0);
     setExecutionResult(null);
     setFlowError(null);
+    setMatchReasoning(null);
     currentOrderIdRef.current = null;
   };
 

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -194,6 +194,7 @@ export default function App() {
   const [executionResult, setExecutionResult] = useState<any>(null);
   const [flowError, setFlowError] = useState<string | null>(null);
   const [attestation, setAttestation] = useState<AttestationResult | null>(null);
+  const [matchReasoning, setMatchReasoning] = useState<{ engine: string; reasoning: string } | null>(null);
   const currentOrderIdRef = useRef<string | null>(null);
 
   // WebSocket onMessage 와 15s 폴백 setTimeout 이 useEffect/startExecutionFlow
@@ -268,6 +269,13 @@ export default function App() {
               if (fallbackTimeoutRef.current !== null) {
                 clearTimeout(fallbackTimeoutRef.current);
                 fallbackTimeoutRef.current = null;
+              }
+              // AI 매칭 근거 저장
+              if (event.reasoning) {
+                setMatchReasoning({
+                  engine: event.engine_used || 'rules',
+                  reasoning: event.reasoning,
+                });
               }
               // 매칭 단계 애니메이션 (5단계)
               setMatchStep(1);
@@ -391,6 +399,7 @@ export default function App() {
       setFlowState('match');
       setMatchStep(0);
       setAttestation(null);
+      setMatchReasoning(null);
 
       // TEE attestation 검증
       try {
@@ -1286,8 +1295,18 @@ export default function App() {
                       <div className="flex items-center gap-2">
                         <span className="text-emerald-500">{'>'}</span>
                         <span className="text-emerald-400/80">Optimal result selected</span>
-                        <span className="text-neutral-600">fill_volume comparison</span>
+                        <span className="text-neutral-600">{matchReasoning?.engine === 'llm' ? 'AI engine won' : 'fill_volume comparison'}</span>
                         <span className="text-emerald-500 ml-auto">OK</span>
+                      </div>
+                    )}
+                    {matchStep >= 4 && matchReasoning && (
+                      <div className="mt-1 px-4 py-2 bg-neutral-900/80 border border-neutral-800/50 rounded">
+                        <div className="flex items-center gap-1.5 mb-1">
+                          <span className={`text-[9px] font-mono uppercase tracking-wider ${matchReasoning.engine === 'llm' ? 'text-purple-400' : 'text-emerald-500/60'}`}>
+                            {matchReasoning.engine === 'llm' ? 'AI Analysis' : 'Engine Analysis'}
+                          </span>
+                        </div>
+                        <p className="text-[10px] text-neutral-400 leading-relaxed">{matchReasoning.reasoning}</p>
                       </div>
                     )}
                     {/* Step 5: Sign + Settle */}
@@ -1519,6 +1538,19 @@ export default function App() {
                       : 'TEE attestation unavailable — verification skipped'}
                   </div>
                 </div>
+
+                {/* AI Matching Analysis */}
+                {matchReasoning && (
+                  <div className="bg-neutral-900/50 border border-neutral-800 rounded-lg p-4 mb-4">
+                    <div className="flex items-center justify-between">
+                      <span className="text-[10px] font-mono text-neutral-600 uppercase tracking-wider">Matching Analysis</span>
+                      <span className={`text-[9px] font-mono ${matchReasoning.engine === 'llm' ? 'text-purple-400/60' : 'text-emerald-500/60'}`}>
+                        {matchReasoning.engine === 'llm' ? 'AI engine' : 'rules engine'}
+                      </span>
+                    </div>
+                    <p className="mt-2 text-xs text-neutral-400 leading-relaxed">{matchReasoning.reasoning}</p>
+                  </div>
+                )}
 
                 {/* Privacy Report */}
                 <div className="bg-neutral-900/50 border border-neutral-800 rounded-lg p-4 mb-6">


### PR DESCRIPTION
## 요약

Closes #27

매칭 엔진의 AI reasoning을 WebSocket 이벤트로 전달하고 프론트엔드 UI에 표시. BuidlHack 데모에서 "AI가 왜 이 가격에 매칭했는지"를 시각적으로 보여줌.

## 변경 사항

### Engine
- `src/matching/schema.py`: LLM 응답 스키마에 `reasoning` 필드 추가 (required)
- `src/matching/prompt.py`: reasoning 작성 지시 추가 (주문 수, 전략, price improvement %)
- `src/matching/rules_engine.py`: synthetic reasoning 생성 (체결별 근거 + 전체 요약)
- `src/matching/engine.py`: `last_engine_used`, `last_reasoning` 인스턴스 변수
- `src/matching/runner.py`: WebSocket broadcast에 `engine_used`, `reasoning` 포함

### Frontend
- `src/App.tsx`: `matchReasoning` state + Phase 3 terminal analysis box + Phase 5 Matching Analysis 카드

## 기술적 판단

- **strict JSON 스키마**에 reasoning 추가: LLM이 반드시 채워야 하므로 빈 응답 불가, 데모에서 항상 표시됨
- **규칙 엔진도 reasoning 생성**: LLM이 동작 안 하는 환경(API 키 없음, 주문 < 3개)에서도 reasoning UI가 작동
- **인스턴스 변수 패턴**: 반환 타입 변경 없이 기존 인터페이스 유지, runner만 추가로 읽으면 됨

## 검증

- pytest: **143 passed**
- ruff: clean
- tsc --noEmit: clean
- 수동 검증: engine + frontend 동시 기동 후 주문 매칭 시 reasoning 표시 확인 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows which matching engine (AI or rules) produced each match and surfaces the engine choice in match events.
  * Provides detailed match reasoning: number of orders analyzed, chosen strategy, execution price basis, filled volume, and buyer/seller price improvements.
  * Displays reasoning in the UI’s match/ success views and ensures reasoning is included with match notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->